### PR TITLE
🚀 Fit button text onto button and add padding for base-sm breakpoints

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -239,7 +239,7 @@ aside nav {
   color: #1f2226;
   opacity: 0.8;
   display: inline;
-  position: relative;
+  position: static;
   float: right;
   max-width: 300px;
   white-space: nowrap;

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -124,7 +124,7 @@ main .container {
 }
 @media (max-width: 960px) {
   main .container {
-    padding: 32px 16px 0 16px !important;
+    padding: 32px 16px 46px 16px !important;
   }
 }
 aside {


### PR DESCRIPTION
This is a PR to fix the text on pagination and to set padding-bottom for base-sm breakpoints to 46px to give a visual barrier between the button and the bottom of the page.