### PR TITLE
bugfix: Fix `ethers.js` example for websockets

### DIFF
--- a/docs/build-blockchain/guides/websocket-connect.md
+++ b/docs/build-blockchain/guides/websocket-connect.md
@@ -109,9 +109,7 @@ func main() {
 <TabItem value="ethers.js" label="Ethers.js">
 
 ```javascript
-const ethers = require("ethers");
-
-const url = wss://rpc.ankr.com/eth/ws/<YOUR_PRIVATE_KEY>     
+const ethers = require("ethers");   
 
 const init = function () {
 
@@ -122,7 +120,6 @@ const init = function () {
         setTimeout(function () {
             wsProvider.destroy()
         }, 1000);
-
     });
 
 };


### PR DESCRIPTION
Removed an erroneous/unnecessary line of code in the `ethers.js` code example for our premium websockets.