### PR TITLE
fix: correct sui-grpc redirect format

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -2132,7 +2132,7 @@
     "to": "/docs/advanced-api/overview/"
   },
   {
-    "from": "rpc-service/chains/chains-api/sui-grpc",
-    "to": "/rpc-service/chains/chains-api/sui/grpc"
+    "from": "docs/rpc-service/chains/chains-api/sui-grpc/index.html",
+    "to": "/docs/rpc-service/chains/chains-api/sui/"
   }
 ]


### PR DESCRIPTION
## Summary

- Fix redirect format for `sui-grpc` to match existing `docs/.../index.html` pattern
- Redirect points to Sui overview page (`/docs/rpc-service/chains/chains-api/sui/`) so published Twitter link works correctly

### Before
```json
"from": "rpc-service/chains/chains-api/sui-grpc",
"to": "/rpc-service/chains/chains-api/sui/grpc"
```

### After
```json
"from": "docs/rpc-service/chains/chains-api/sui-grpc/index.html",
"to": "/docs/rpc-service/chains/chains-api/sui/"
```

## Test plan
- [ ] Visit `https://www.ankr.com/docs/rpc-service/chains/chains-api/sui-grpc/` — should redirect to Sui overview page

🤖 Generated with [Claude Code](https://claude.com/claude-code)