### PR TITLE
Merge stage to main: Sui gRPC/GraphQL endpoints + redirect fix

### DIFF
--- a/pages/rpc-service/chains/chains-api/_meta.json
+++ b/pages/rpc-service/chains/chains-api/_meta.json
@@ -65,7 +65,6 @@
   "stellar": "Stellar",
   "story": "Story",
   "sui": "Sui",
-  "sui-grpc": "Sui gRPC",
   "swell": "Swell",
   "syscoin": "Syscoin",
   "tac": "TAC",

--- a/pages/rpc-service/chains/chains-api/sui/_meta.json
+++ b/pages/rpc-service/chains/chains-api/sui/_meta.json
@@ -1,0 +1,6 @@
+{
+  "index": "Overview",
+  "json-rpc": "JSON-RPC",
+  "grpc": "gRPC",
+  "graphql": "GraphQL"
+}

--- a/pages/rpc-service/chains/chains-api/sui/graphql.mdx
+++ b/pages/rpc-service/chains/chains-api/sui/graphql.mdx
@@ -1,0 +1,86 @@
+import { Callout } from "components";
+
+# Sui GraphQL
+<br/>
+
+<img src="/docs/build/chains-list/sui.png" className="responsive-pic" width="800" />
+
+> Sui GraphQL API is available on [Web3 API platform](https://www.ankr.com/rpc/sui).
+
+The Sui GraphQL RPC provides a flexible query interface for interacting with the Sui blockchain. Unlike JSON-RPC, GraphQL lets you request exactly the data you need in a single call — reducing overfetching and round trips.
+
+With GraphQL, you can compose queries that combine objects, transactions, balances, checkpoints, and more into a single request. It supports pagination, filtering, and nested lookups, making it well suited for frontends, dashboards, and analytics tools.
+
+## Endpoint
+
+| Network | Endpoint |
+|---------|----------|
+| Mainnet | `https://rpc.ankr.com/http/sui_graphql` |
+
+For Premium users, append your token to the URL: `https://rpc.ankr.com/http/sui_graphql/{your_token}`
+
+---
+
+## Request example
+
+Query the latest checkpoint:
+
+```shell
+curl -X POST https://rpc.ankr.com/http/sui_graphql \
+-H 'Content-Type: application/json' \
+-d '{
+  "query": "{ checkpoint { sequenceNumber digest timestamp } }"
+}'
+```
+
+## Response example
+
+```json
+{
+  "data": {
+    "checkpoint": {
+      "sequenceNumber": 214225619,
+      "digest": "GNSviTUX6DXkiCPKYDo1uihJsm5oRcjtvrkT8mVQyay8",
+      "timestamp": "2025-03-24T12:00:00Z"
+    }
+  }
+}
+```
+
+---
+
+## Query examples
+
+### Get object by ID
+
+```shell
+curl -X POST https://rpc.ankr.com/http/sui_graphql \
+-H 'Content-Type: application/json' \
+-d '{
+  "query": "{ object(address: \"0x5\") { address version digest owner { __typename } } }"
+}'
+```
+
+### Get address balances
+
+```shell
+curl -X POST https://rpc.ankr.com/http/sui_graphql \
+-H 'Content-Type: application/json' \
+-d '{
+  "query": "{ address(address: \"0xYOUR_ADDRESS\") { balance { totalBalance coinType { repr } } } }"
+}'
+```
+
+---
+
+## Key features
+
+- **Composable queries** — request multiple related resources in a single call.
+- **Pagination** — default 50 items per page, up to 200 for multi-get operations.
+- **Filtering** — narrow results by type, owner, checkpoint range, and more.
+- **No overfetching** — get only the fields you need.
+
+## Further reading
+
+- [Sui GraphQL reference](https://docs.sui.io/references/sui-graphql)
+- [Sui GraphQL RPC concepts](https://docs.sui.io/concepts/data-access/graphql-rpc)

--- a/pages/rpc-service/chains/chains-api/sui/grpc.mdx
+++ b/pages/rpc-service/chains/chains-api/sui/grpc.mdx
@@ -15,19 +15,31 @@ In addition to standard request–response calls, gRPC supports server-side stre
 
 The Sui gRPC server fully supports server reflection, allowing tools like `grpcurl` to discover available services and methods at runtime without requiring local `.proto` files.
 
+## Endpoints
+
+| Network | Endpoint | Description |
+|---------|----------|-------------|
+| Mainnet | `sui.grpc.ankr.com:443` | Standard gRPC |
+| Testnet | `sui-testnet.grpc.ankr.com:443` | Testnet gRPC |
+| Mainnet Archive | `archive.sui.grpc.ankr.com:443` | Historical data access |
+
+For Premium users, pass your token via the `x-token` header (e.g., `-H "x-token: your-token"`).
+
+**Archive endpoint** — provides access to historical Sui data that standard full nodes may have pruned. It exposes the same `LedgerService` API, so you can use the same client code. Use it when querying older transactions, checkpoints, or objects that are no longer available on current nodes.
+
 ## Methods list
 
 **Ledger Service**:
 
 Provides read access to global ledger metadata such as chain identifiers, epochs, checkpoints, timestamps, and system-level information.
 
-  * [`BatchGetObjects`](/rpc-service/chains/chains-api/sui-grpc/#batchgetobjects) — Retrieves multiple objects in one request.
-  * [`BatchGetTransactions`](/rpc-service/chains/chains-api/sui-grpc/#batchgettransactions) — Retrieves multiple transactions by digest.
-  * [`GetCheckpoint`](/rpc-service/chains/chains-api/sui-grpc/#getcheckpoint) — Retrieves a checkpoint by sequence or digest.
-  * [`GetEpoch`](/rpc-service/chains/chains-api/sui-grpc/#getepoch) — Retrieves details for a specific epoch.
-  * [`GetObject`](/rpc-service/chains/chains-api/sui-grpc/#getobject) — Retrieves a single object by ID.
-  * [`GetServiceInfo`](/rpc-service/chains/chains-api/sui-grpc/#getserviceinfo) — Retrieves node, chain, and service metadata.
-  * [`GetTransaction`](/rpc-service/chains/chains-api/sui-grpc/#gettransaction) — Retrieves a single transaction by digest.
+  * [`BatchGetObjects`](/rpc-service/chains/chains-api/sui/grpc#batchgetobjects) — Retrieves multiple objects in one request.
+  * [`BatchGetTransactions`](/rpc-service/chains/chains-api/sui/grpc#batchgettransactions) — Retrieves multiple transactions by digest.
+  * [`GetCheckpoint`](/rpc-service/chains/chains-api/sui/grpc#getcheckpoint) — Retrieves a checkpoint by sequence or digest.
+  * [`GetEpoch`](/rpc-service/chains/chains-api/sui/grpc#getepoch) — Retrieves details for a specific epoch.
+  * [`GetObject`](/rpc-service/chains/chains-api/sui/grpc#getobject) — Retrieves a single object by ID.
+  * [`GetServiceInfo`](/rpc-service/chains/chains-api/sui/grpc#getserviceinfo) — Retrieves node, chain, and service metadata.
+  * [`GetTransaction`](/rpc-service/chains/chains-api/sui/grpc#gettransaction) — Retrieves a single transaction by digest.
 
 ---
 
@@ -35,10 +47,10 @@ Provides read access to global ledger metadata such as chain identifiers, epochs
 
 Exposes Move package metadata, allowing you to query on-chain modules and published Move code.
 
-  * [`GetDatatype`](/rpc-service/chains/chains-api/sui-grpc/#getdatatype) — Retrieves metadata about a Move struct/type.
-  * [`GetFunction`](/rpc-service/chains/chains-api/sui-grpc/#getfunction) — Retrieves metadata about a Move function.
-  * [`GetPackage`](/rpc-service/chains/chains-api/sui-grpc/#getpackage) — Retrieves information about a Move package.
-  * [`ListPackageVersions`](/rpc-service/chains/chains-api/sui-grpc/#listpackageversions) — Lists the published versions of a package.
+  * [`GetDatatype`](/rpc-service/chains/chains-api/sui/grpc#getdatatype) — Retrieves metadata about a Move struct/type.
+  * [`GetFunction`](/rpc-service/chains/chains-api/sui/grpc#getfunction) — Retrieves metadata about a Move function.
+  * [`GetPackage`](/rpc-service/chains/chains-api/sui/grpc#getpackage) — Retrieves information about a Move package.
+  * [`ListPackageVersions`](/rpc-service/chains/chains-api/sui/grpc#listpackageversions) — Lists the published versions of a package.
 
 ---
 
@@ -46,7 +58,7 @@ Exposes Move package metadata, allowing you to query on-chain modules and publis
 
 Performs cryptographic verification for signatures, proofs, and signed messages.
 
-  * [`VerifySignature`](/rpc-service/chains/chains-api/sui-grpc/#verifysignature): Validates a signature against a message and public key.
+  * [`VerifySignature`](/rpc-service/chains/chains-api/sui/grpc#verifysignature): Validates a signature against a message and public key.
 
 ---
 
@@ -54,11 +66,11 @@ Performs cryptographic verification for signatures, proofs, and signed messages.
 
 Provides access to detailed on-chain state including objects, balances, ownership, object layouts, dynamic fields, and protocol configuration. This is the main service for querying Sui state data.
 
-  * [`GetBalance`](/rpc-service/chains/chains-api/sui-grpc/#getbalance) — Retrieves balance for a specific coin type.
-  * [`GetCoinInfo`](/rpc-service/chains/chains-api/sui-grpc/#getcoininfo) — Retrieves metadata for a coin type.
-  * [`ListBalances`](/rpc-service/chains/chains-api/sui-grpc/#listbalances) — Lists all coin balances for an address.
-  * [`ListDynamicFields`](/rpc-service/chains/chains-api/sui-grpc/#listdynamicfields) — Lists dynamic fields under an object.
-  * [`ListOwnedObjects`](/rpc-service/chains/chains-api/sui-grpc/#listownedobjects) — Lists objects owned by an address.
+  * [`GetBalance`](/rpc-service/chains/chains-api/sui/grpc#getbalance) — Retrieves balance for a specific coin type.
+  * [`GetCoinInfo`](/rpc-service/chains/chains-api/sui/grpc#getcoininfo) — Retrieves metadata for a coin type.
+  * [`ListBalances`](/rpc-service/chains/chains-api/sui/grpc#listbalances) — Lists all coin balances for an address.
+  * [`ListDynamicFields`](/rpc-service/chains/chains-api/sui/grpc#listdynamicfields) — Lists dynamic fields under an object.
+  * [`ListOwnedObjects`](/rpc-service/chains/chains-api/sui/grpc#listownedobjects) — Lists objects owned by an address.
 
 ---
 
@@ -66,14 +78,14 @@ Provides access to detailed on-chain state including objects, balances, ownershi
 
 Supports server-side streaming for real-time updates. Use it to subscribe to events, transactions, checkpoints, or other continuous data feeds.
 
-  * [`SubscribeCheckpoints`](/rpc-service/chains/chains-api/sui-grpc/#subscribecheckpoints) — Subscribes to a stream of newly produced checkpoints.
+  * [`SubscribeCheckpoints`](/rpc-service/chains/chains-api/sui/grpc#subscribecheckpoints) — Subscribes to a stream of newly produced checkpoints.
 
 **Transaction Execution Service**:
 
 Lets you simulate and execute transactions, fetch execution effects, run dry-runs, and retrieve transaction metadata. This is the primary service for write operations and transaction analysis.
 
-  * [`ExecuteTransaction`](/rpc-service/chains/chains-api/sui-grpc/#executetransaction) — Executes a signed transaction on-chain.
-  * [`SimulateTransaction`](/rpc-service/chains/chains-api/sui-grpc/#simulatetransaction) — Simulates a transaction without executing it.
+  * [`ExecuteTransaction`](/rpc-service/chains/chains-api/sui/grpc#executetransaction) — Executes a signed transaction on-chain.
+  * [`SimulateTransaction`](/rpc-service/chains/chains-api/sui/grpc#simulatetransaction) — Simulates a transaction without executing it.
 
 ---
 

--- a/pages/rpc-service/chains/chains-api/sui/index.mdx
+++ b/pages/rpc-service/chains/chains-api/sui/index.mdx
@@ -1,0 +1,72 @@
+import { Callout } from "components";
+
+# Sui
+
+<br/>
+
+<img src="/docs/build/chains-list/sui.png" className="responsive-pic" width="800" />
+
+<Callout type="tip">
+Available for [Freemium and Premium](/rpc-service/service-plans/#service-plans-comparison) users.
+</Callout>
+
+> Sui API is available on [Web3 API platform](https://www.ankr.com/rpc/sui).
+
+*Sui* is the first permissionless Layer 1 blockchain designed from the ground up to enable creators and developers to build experiences that cater to the next billion users in Web3. Sui is horizontally scalable to support a wide range of application development with unrivaled speed at low cost.
+
+Ankr provides multiple interfaces for interacting with Sui — JSON-RPC, gRPC, and GraphQL — across mainnet, testnet, and archival data.
+
+---
+
+## Endpoints
+
+| Interface | Network | Endpoint | Auth |
+|-----------|---------|----------|------|
+| JSON-RPC | Mainnet | `https://rpc.ankr.com/sui` | Token for Premium |
+| JSON-RPC | Testnet | `https://rpc.ankr.com/sui_testnet` | Token for Premium |
+| gRPC | Mainnet | `sui.grpc.ankr.com:443` | `x-token` header for Premium |
+| gRPC | Testnet | `sui-testnet.grpc.ankr.com:443` | `x-token` header for Premium |
+| gRPC Archive | Mainnet | `archive.sui.grpc.ankr.com:443` | `x-token` header for Premium |
+| GraphQL | Mainnet | `https://rpc.ankr.com/http/sui_graphql` | Token for Premium |
+
+For Premium endpoints, append your token to the URL (for HTTP-based APIs) or pass it via the `x-token` header (for gRPC).
+
+---
+
+## Interfaces
+
+### JSON-RPC
+
+The standard [JSON-RPC 2.0](https://www.jsonrpc.org/specification) interface for reading blockchain data and sending transactions. This is the most widely used API for Sui dApp development.
+
+[View JSON-RPC methods →](/rpc-service/chains/chains-api/sui/json-rpc)
+
+### gRPC
+
+A high-performance interface using [Protocol Buffers](https://protobuf.dev/overview/) for fast, type-safe, and bandwidth-efficient communication. gRPC supports server-side streaming for real-time data delivery and automatic client generation in TypeScript, Go, Rust, and more. Ideal for indexers, explorers, and backend systems.
+
+[View gRPC methods →](/rpc-service/chains/chains-api/sui/grpc)
+
+### GraphQL
+
+A flexible query language that lets you request exactly the data you need in a single call. Sui's GraphQL RPC provides composable queries for on-chain state — objects, transactions, balances, checkpoints — without overfetching. It supports pagination, filtering, and nested lookups.
+
+[View GraphQL documentation →](/rpc-service/chains/chains-api/sui/graphql)
+
+---
+
+## gRPC Archive
+
+The gRPC Archive endpoint (`archive.sui.grpc.ankr.com:443`) provides access to historical Sui network data that standard full nodes may have pruned. It exposes the same `LedgerService` gRPC API as the standard gRPC endpoint, so you can use the same client code and methods.
+
+Use the Archive endpoint when you need to query older transactions, checkpoints, or objects that are no longer available on current full nodes. A common pattern is to first query the standard endpoint and fall back to the Archive endpoint if the data is not found.
+
+---
+
+## Getting started
+
+1. **Get your API token** — Sign up at [ankr.com/rpc](https://www.ankr.com/rpc/sui) to get a Premium token, or use the public endpoints without authentication.
+2. **Choose your interface** — Pick JSON-RPC, gRPC, or GraphQL based on your use case.
+3. **Connect** — Use the endpoints from the table above with your preferred client library or tool.
+
+Official Sui links: [Website](https://sui.io/), [Docs](https://docs.sui.io/), [GitHub](https://github.com/MystenLabs)

--- a/pages/rpc-service/chains/chains-api/sui/json-rpc.mdx
+++ b/pages/rpc-service/chains/chains-api/sui/json-rpc.mdx
@@ -17,60 +17,60 @@ The API interaction follows the [JSON-RPC](https://www.jsonrpc.org/specification
 
 ## Methods supported
 
-  * [`sui_devInspectTransactionBlock`](/rpc-service/chains/chains-api/sui/#sui_devinspecttransactionblock) — runs the transaction in dev-inspect mode.
-  * [`sui_dryRunTransactionBlock`](/rpc-service/chains/chains-api/sui/#sui_dryruntransactionblock) — retrieves transaction execution effects including the gas cost summary, while the effects are not committed to the chain.
-  * [`sui_executeTransactionBlock`](/rpc-service/chains/chains-api/sui/#sui_executetransactionblock) — executes the transaction and wait for results if desired.
-  * [`sui_getChainIdentifier`](/rpc-service/chains/chains-api/sui/#sui_getchainidentifier) — retrieves the chain's identifier.
-  * [`sui_getCheckpoint`](/rpc-service/chains/chains-api/sui/#sui_getcheckpoint) — retrieves a checkpoint.
-  * [`sui_getCheckpoints`](/rpc-service/chains/chains-api/sui/#sui_getcheckpoints) — retrieves a paginated list of checkpoints.
-  * [`sui_getEvents`](/rpc-service/chains/chains-api/sui/#sui_getevents) — retrieves transaction events.
-  * [`sui_getLatestCheckpointSequenceNumber`](/rpc-service/chains/chains-api/sui/#sui_getlatestcheckpointsequencenumber) — retrieves the sequence number of the latest checkpoint that has been executed.
-  * [`sui_getLoadedChildObjects`](/rpc-service/chains/chains-api/sui/#sui_getloadedchildobjects) — retrieves loaded child objects.
-  * [`sui_getMoveFunctionArgTypes`](/rpc-service/chains/chains-api/sui/#sui_getmovefunctionargtypes) — retrieves the argument types of a Move function, based on normalized Type.
-  * [`sui_getNormalizedMoveFunction`](/rpc-service/chains/chains-api/sui/#sui_getnormalizedmovefunction) — retrieves a structured representation of Move function.
-  * [`sui_getNormalizedMoveModule`](/rpc-service/chains/chains-api/sui/#sui_getnormalizedmovemodule) — retrieves a structured representation of Move module.
-  * [`sui_getNormalizedMoveModulesByPackage`](/rpc-service/chains/chains-api/sui/#sui_getnormalizedmovemodulesbypackage) — retrieves structured representations of all modules in the given package.
-  * [`sui_getNormalizedMoveStruct`](/rpc-service/chains/chains-api/sui/#sui_getnormalizedmovestruct) — retrieves a structured representation of Move struct.
-  * [`sui_getObject`](/rpc-service/chains/chains-api/sui/#sui_getobject) — retrieves the object information for a specified object.
-  * [`sui_getProtocolConfig`](/rpc-service/chains/chains-api/sui/#sui_getprotocolconfig) — retrieves the protocol config table for the given version number.
-  * [`sui_getTotalTransactionBlocks`](/rpc-service/chains/chains-api/sui/#sui_gettotaltransactionblocks) — retrieves the total number of transactions known to the server.
-  * [`sui_getTransactionBlock`](/rpc-service/chains/chains-api/sui/#sui_gettransactionblock) — retrieves the transaction response object.
-  * [`sui_multiGetObjects`](/rpc-service/chains/chains-api/sui/#sui_multigetobjects) — retrieves the object data for a list of objects.
-  * [`sui_multiGetTransactionBlocks`](/rpc-service/chains/chains-api/sui/#sui_multigettransactionblocks) — retrieves  an ordered list of transaction responses.
-  * [`sui_tryGetPastObject`](/rpc-service/chains/chains-api/sui/#sui_trygetpastobject) — retrieves the object information for a specified version.
-  * [`sui_tryMultiGetPastObjects`](/rpc-service/chains/chains-api/sui/#sui_tryMultigetpastobjects) — retrieves the object information for a specified version.
-  * [`suix_getAllBalances`](/rpc-service/chains/chains-api/sui/#suix_getallbalances) — retrieves the total coin balance for all coin type, owned by the address owner.
-  * [`suix_getAllCoins`](/rpc-service/chains/chains-api/sui/#suix_getallcoins) — retrieves all Coin objects owned by an address.
-  * [`suix_getBalance`](/rpc-service/chains/chains-api/sui/#suix_getbalance) — retrieves the total coin balance for one coin type, owned by the address owner.
-  * [`suix_getCoinMetadata`](/rpc-service/chains/chains-api/sui/#suix_getcoinmetadata) — retrieves metadata (as symbol or decimals) for a coin.
-  * [`suix_getCoins`](/rpc-service/chains/chains-api/sui/#suix_getcoins) — retrieves all coin type objects owned by an address.
-  * [`suix_getCommitteeInfo`](/rpc-service/chains/chains-api/sui/#suix_getcommitteeinfo) — retrieves the committee information for the epoch specified.
-  * [`suix_getDynamicFieldObject`](/rpc-service/chains/chains-api/sui/#suix_getdynamicfieldobject) — retrieves the dynamic field object information for a specified object.
-  * [`suix_getDynamicFields`](/rpc-service/chains/chains-api/sui/#suix_getdynamicfields) — retrieves the list of dynamic field objects owned by an object.
-  * [`suix_getLatestSuiSystemState`](/rpc-service/chains/chains-api/sui/#suix_getlatestsuisystemstate) — retrieves the latest SUI system state object on-chain.
-  * [`suix_getOwnedObjects`](/rpc-service/chains/chains-api/sui/#suix_getownedobjects) — retrieves the list of objects owned by an address.
-  * [`suix_getReferenceGasPrice`](/rpc-service/chains/chains-api/sui/#suix_getreferencegasprice) — retrieves the reference gas price for the network.
-  * [`suix_getStakes`](/rpc-service/chains/chains-api/sui/#suix_getstakes) — retrieves all `DelegatedStake`.
-  * [`suix_getStakesByIds`](/rpc-service/chains/chains-api/sui/#suix_getstakesbyids) — retrieves one or more `DelegatedStake`s.
-  * [`suix_getTotalSupply`](/rpc-service/chains/chains-api/sui/#suix_gettotalsupply) — retrieves total supply for a coin.
-  * [`suix_getValidatorsApy`](/rpc-service/chains/chains-api/sui/#suix_getvalidatorsapy) — retrieves the validator APY.
-  * [`suix_queryEvents`](/rpc-service/chains/chains-api/sui/#suix_queryevents) — retrieves the list of events for a specified query criteria.
-  * [`suix_queryTransactionBlocks`](/rpc-service/chains/chains-api/sui/#suix_querytransactionblocks) — retrieves list of transactions for a specified query criteria.
-  * [`suix_resolveNameServiceAddress`](/rpc-service/chains/chains-api/sui/#suix_resolvenameserviceaddress) — retrieves the resolved address given the resolver and name.
-  * [`suix_resolveNameServiceNames`](/rpc-service/chains/chains-api/sui/#suix_resolvenameservicenames) — retrieves  the resolved names given an address.
-  * [`unsafe_batchTransaction`](/rpc-service/chains/chains-api/sui/#unsafe_batchtransaction) — creates an unsigned batched transaction.
-  * [`unsafe_mergeCoins`](/rpc-service/chains/chains-api/sui/#unsafe_mergecoins) — creates an unsigned transaction to merge multiple coins into one coin.
-  * [`unsafe_moveCall`](/rpc-service/chains/chains-api/sui/#unsafe_movecall) — creates an unsigned transaction to execute a Move call on the network by calling the specified function in the module of a given package.
-  * [`unsafe_pay`](/rpc-service/chains/chains-api/sui/#unsafe_pay) — sends `Coin<T>` to a list of addresses.
-  * [`unsafe_payAllSui`](/rpc-service/chains/chains-api/sui/#unsafe_payallsui) — sends all SUI coins to one recipient.
-  * [`unsafe_paySui`](/rpc-service/chains/chains-api/sui/#unsafe_paysui) — sends SUI coins to a list of addresses, following a list of amounts.
-  * [`unsafe_publish`](/rpc-service/chains/chains-api/sui/#unsafe_publish) — creates an unsigned transaction to publish a Move package.
-  * [`unsafe_requestAddStake`](/rpc-service/chains/chains-api/sui/#unsafe_requestaddstake) — adds the stake to a validator's staking pool using multiple coins and amount.
-  * [`unsafe_requestWithdrawStake`](/rpc-service/chains/chains-api/sui/#unsafe_requestwithdrawstake) — withdraws the stake from a validator's staking pool.
-  * [`unsafe_splitCoin`](/rpc-service/chains/chains-api/sui/#unsafe_splitcoin) — creates an unsigned transaction to split a coin object into multiple coins.
-  * [`unsafe_splitCoinEqual`](/rpc-service/chains/chains-api/sui/#unsafe_splitcoinequal) — creates an unsigned transaction to split a coin object into multiple equal-size coins.
-  * [`unsafe_transferObject`](/rpc-service/chains/chains-api/sui/#unsafe_transferobject) — creates an unsigned transaction to transfer an object from one address to another.
-  * [`unsafe_transferSui`](/rpc-service/chains/chains-api/sui/#unsafe_transfersui) — an unsigned transaction to send SUI coin object to a Sui address.
+  * [`sui_devInspectTransactionBlock`](/rpc-service/chains/chains-api/sui/json-rpc#sui_devinspecttransactionblock) — runs the transaction in dev-inspect mode.
+  * [`sui_dryRunTransactionBlock`](/rpc-service/chains/chains-api/sui/json-rpc#sui_dryruntransactionblock) — retrieves transaction execution effects including the gas cost summary, while the effects are not committed to the chain.
+  * [`sui_executeTransactionBlock`](/rpc-service/chains/chains-api/sui/json-rpc#sui_executetransactionblock) — executes the transaction and wait for results if desired.
+  * [`sui_getChainIdentifier`](/rpc-service/chains/chains-api/sui/json-rpc#sui_getchainidentifier) — retrieves the chain's identifier.
+  * [`sui_getCheckpoint`](/rpc-service/chains/chains-api/sui/json-rpc#sui_getcheckpoint) — retrieves a checkpoint.
+  * [`sui_getCheckpoints`](/rpc-service/chains/chains-api/sui/json-rpc#sui_getcheckpoints) — retrieves a paginated list of checkpoints.
+  * [`sui_getEvents`](/rpc-service/chains/chains-api/sui/json-rpc#sui_getevents) — retrieves transaction events.
+  * [`sui_getLatestCheckpointSequenceNumber`](/rpc-service/chains/chains-api/sui/json-rpc#sui_getlatestcheckpointsequencenumber) — retrieves the sequence number of the latest checkpoint that has been executed.
+  * [`sui_getLoadedChildObjects`](/rpc-service/chains/chains-api/sui/json-rpc#sui_getloadedchildobjects) — retrieves loaded child objects.
+  * [`sui_getMoveFunctionArgTypes`](/rpc-service/chains/chains-api/sui/json-rpc#sui_getmovefunctionargtypes) — retrieves the argument types of a Move function, based on normalized Type.
+  * [`sui_getNormalizedMoveFunction`](/rpc-service/chains/chains-api/sui/json-rpc#sui_getnormalizedmovefunction) — retrieves a structured representation of Move function.
+  * [`sui_getNormalizedMoveModule`](/rpc-service/chains/chains-api/sui/json-rpc#sui_getnormalizedmovemodule) — retrieves a structured representation of Move module.
+  * [`sui_getNormalizedMoveModulesByPackage`](/rpc-service/chains/chains-api/sui/json-rpc#sui_getnormalizedmovemodulesbypackage) — retrieves structured representations of all modules in the given package.
+  * [`sui_getNormalizedMoveStruct`](/rpc-service/chains/chains-api/sui/json-rpc#sui_getnormalizedmovestruct) — retrieves a structured representation of Move struct.
+  * [`sui_getObject`](/rpc-service/chains/chains-api/sui/json-rpc#sui_getobject) — retrieves the object information for a specified object.
+  * [`sui_getProtocolConfig`](/rpc-service/chains/chains-api/sui/json-rpc#sui_getprotocolconfig) — retrieves the protocol config table for the given version number.
+  * [`sui_getTotalTransactionBlocks`](/rpc-service/chains/chains-api/sui/json-rpc#sui_gettotaltransactionblocks) — retrieves the total number of transactions known to the server.
+  * [`sui_getTransactionBlock`](/rpc-service/chains/chains-api/sui/json-rpc#sui_gettransactionblock) — retrieves the transaction response object.
+  * [`sui_multiGetObjects`](/rpc-service/chains/chains-api/sui/json-rpc#sui_multigetobjects) — retrieves the object data for a list of objects.
+  * [`sui_multiGetTransactionBlocks`](/rpc-service/chains/chains-api/sui/json-rpc#sui_multigettransactionblocks) — retrieves  an ordered list of transaction responses.
+  * [`sui_tryGetPastObject`](/rpc-service/chains/chains-api/sui/json-rpc#sui_trygetpastobject) — retrieves the object information for a specified version.
+  * [`sui_tryMultiGetPastObjects`](/rpc-service/chains/chains-api/sui/json-rpc#sui_tryMultigetpastobjects) — retrieves the object information for a specified version.
+  * [`suix_getAllBalances`](/rpc-service/chains/chains-api/sui/json-rpc#suix_getallbalances) — retrieves the total coin balance for all coin type, owned by the address owner.
+  * [`suix_getAllCoins`](/rpc-service/chains/chains-api/sui/json-rpc#suix_getallcoins) — retrieves all Coin objects owned by an address.
+  * [`suix_getBalance`](/rpc-service/chains/chains-api/sui/json-rpc#suix_getbalance) — retrieves the total coin balance for one coin type, owned by the address owner.
+  * [`suix_getCoinMetadata`](/rpc-service/chains/chains-api/sui/json-rpc#suix_getcoinmetadata) — retrieves metadata (as symbol or decimals) for a coin.
+  * [`suix_getCoins`](/rpc-service/chains/chains-api/sui/json-rpc#suix_getcoins) — retrieves all coin type objects owned by an address.
+  * [`suix_getCommitteeInfo`](/rpc-service/chains/chains-api/sui/json-rpc#suix_getcommitteeinfo) — retrieves the committee information for the epoch specified.
+  * [`suix_getDynamicFieldObject`](/rpc-service/chains/chains-api/sui/json-rpc#suix_getdynamicfieldobject) — retrieves the dynamic field object information for a specified object.
+  * [`suix_getDynamicFields`](/rpc-service/chains/chains-api/sui/json-rpc#suix_getdynamicfields) — retrieves the list of dynamic field objects owned by an object.
+  * [`suix_getLatestSuiSystemState`](/rpc-service/chains/chains-api/sui/json-rpc#suix_getlatestsuisystemstate) — retrieves the latest SUI system state object on-chain.
+  * [`suix_getOwnedObjects`](/rpc-service/chains/chains-api/sui/json-rpc#suix_getownedobjects) — retrieves the list of objects owned by an address.
+  * [`suix_getReferenceGasPrice`](/rpc-service/chains/chains-api/sui/json-rpc#suix_getreferencegasprice) — retrieves the reference gas price for the network.
+  * [`suix_getStakes`](/rpc-service/chains/chains-api/sui/json-rpc#suix_getstakes) — retrieves all `DelegatedStake`.
+  * [`suix_getStakesByIds`](/rpc-service/chains/chains-api/sui/json-rpc#suix_getstakesbyids) — retrieves one or more `DelegatedStake`s.
+  * [`suix_getTotalSupply`](/rpc-service/chains/chains-api/sui/json-rpc#suix_gettotalsupply) — retrieves total supply for a coin.
+  * [`suix_getValidatorsApy`](/rpc-service/chains/chains-api/sui/json-rpc#suix_getvalidatorsapy) — retrieves the validator APY.
+  * [`suix_queryEvents`](/rpc-service/chains/chains-api/sui/json-rpc#suix_queryevents) — retrieves the list of events for a specified query criteria.
+  * [`suix_queryTransactionBlocks`](/rpc-service/chains/chains-api/sui/json-rpc#suix_querytransactionblocks) — retrieves list of transactions for a specified query criteria.
+  * [`suix_resolveNameServiceAddress`](/rpc-service/chains/chains-api/sui/json-rpc#suix_resolvenameserviceaddress) — retrieves the resolved address given the resolver and name.
+  * [`suix_resolveNameServiceNames`](/rpc-service/chains/chains-api/sui/json-rpc#suix_resolvenameservicenames) — retrieves  the resolved names given an address.
+  * [`unsafe_batchTransaction`](/rpc-service/chains/chains-api/sui/json-rpc#unsafe_batchtransaction) — creates an unsigned batched transaction.
+  * [`unsafe_mergeCoins`](/rpc-service/chains/chains-api/sui/json-rpc#unsafe_mergecoins) — creates an unsigned transaction to merge multiple coins into one coin.
+  * [`unsafe_moveCall`](/rpc-service/chains/chains-api/sui/json-rpc#unsafe_movecall) — creates an unsigned transaction to execute a Move call on the network by calling the specified function in the module of a given package.
+  * [`unsafe_pay`](/rpc-service/chains/chains-api/sui/json-rpc#unsafe_pay) — sends `Coin<T>` to a list of addresses.
+  * [`unsafe_payAllSui`](/rpc-service/chains/chains-api/sui/json-rpc#unsafe_payallsui) — sends all SUI coins to one recipient.
+  * [`unsafe_paySui`](/rpc-service/chains/chains-api/sui/json-rpc#unsafe_paysui) — sends SUI coins to a list of addresses, following a list of amounts.
+  * [`unsafe_publish`](/rpc-service/chains/chains-api/sui/json-rpc#unsafe_publish) — creates an unsigned transaction to publish a Move package.
+  * [`unsafe_requestAddStake`](/rpc-service/chains/chains-api/sui/json-rpc#unsafe_requestaddstake) — adds the stake to a validator's staking pool using multiple coins and amount.
+  * [`unsafe_requestWithdrawStake`](/rpc-service/chains/chains-api/sui/json-rpc#unsafe_requestwithdrawstake) — withdraws the stake from a validator's staking pool.
+  * [`unsafe_splitCoin`](/rpc-service/chains/chains-api/sui/json-rpc#unsafe_splitcoin) — creates an unsigned transaction to split a coin object into multiple coins.
+  * [`unsafe_splitCoinEqual`](/rpc-service/chains/chains-api/sui/json-rpc#unsafe_splitcoinequal) — creates an unsigned transaction to split a coin object into multiple equal-size coins.
+  * [`unsafe_transferObject`](/rpc-service/chains/chains-api/sui/json-rpc#unsafe_transferobject) — creates an unsigned transaction to transfer an object from one address to another.
+  * [`unsafe_transferSui`](/rpc-service/chains/chains-api/sui/json-rpc#unsafe_transfersui) — an unsigned transaction to send SUI coin object to a Sui address.
 
 ---
 

--- a/pages/rpc-service/chains/chains-list.mdx
+++ b/pages/rpc-service/chains/chains-list.mdx
@@ -9953,15 +9953,17 @@ Official quick links: [Website](https://sui.io/), [Docs](https://docs.sui.io/), 
 
 ### Networks
 
-  * Mainnet (`HTTPS` and `WSS`)
-  * Testnet (`HTTPS` and `WSS`)
+  * Mainnet (`HTTPS`, `WSS`, `gRPC`, `GraphQL`)
+  * Testnet (`HTTPS`, `WSS`, `gRPC`)
 
 ### API methods
 
-For Sui, we support blockchain interaction via the following methods:
+For Sui, we support blockchain interaction via the following interfaces:
 
-  * [RPC methods](/rpc-service/chains/chains-api/sui/)
-  * [gRPC methods](/rpc-service/chains/chains-api/sui-grpc/)
+  * [Overview — all Sui interfaces](/rpc-service/chains/chains-api/sui/)
+  * [JSON-RPC methods](/rpc-service/chains/chains-api/sui/json-rpc)
+  * [gRPC methods](/rpc-service/chains/chains-api/sui/grpc) (mainnet, testnet, archive)
+  * [GraphQL](/rpc-service/chains/chains-api/sui/graphql) (mainnet)
 
 #### Unsupported
 

--- a/redirects.json
+++ b/redirects.json
@@ -2130,5 +2130,9 @@
   {
     "from": "docs/advanced-api/index.html",
     "to": "/docs/advanced-api/overview/"
+  },
+  {
+    "from": "rpc-service/chains/chains-api/sui-grpc",
+    "to": "/rpc-service/chains/chains-api/sui/grpc"
   }
 ]

--- a/redirects.json
+++ b/redirects.json
@@ -2132,7 +2132,7 @@
     "to": "/docs/advanced-api/overview/"
   },
   {
-    "from": "rpc-service/chains/chains-api/sui-grpc",
-    "to": "/rpc-service/chains/chains-api/sui/grpc"
+    "from": "docs/rpc-service/chains/chains-api/sui-grpc/index.html",
+    "to": "/docs/rpc-service/chains/chains-api/sui/"
   }
 ]


### PR DESCRIPTION
## Summary

- feat: add Sui gRPC archive, testnet, and GraphQL endpoints (#1936)
- fix: correct sui-grpc redirect format (#1939)
- Update stage (#1935)

## Test plan
- [x] Verified on stage: `https://www-stage.ankr.com/docs/rpc-service/chains/chains-api/sui/`
- [x] Redirect works: `sui-grpc/` → `sui/`
- [ ] Deploy to PROD and verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)