### PR TITLE
fix: correct sui-grpc redirect format

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -2132,7 +2132,7 @@
     "to": "/docs/advanced-api/overview/"
   },
   {
-    "from": "rpc-service/chains/chains-api/sui-grpc",
-    "to": "/rpc-service/chains/chains-api/sui/grpc"
+    "from": "docs/rpc-service/chains/chains-api/sui-grpc/index.html",
+    "to": "/docs/rpc-service/chains/chains-api/sui/"
   }
 ]


### PR DESCRIPTION
## Summary

- Fix redirect format for `sui-grpc` to use `docs/.../index.html` pattern (consistent with all other redirects)
- Point to Sui overview page so the published Twitter link works: `sui-grpc/` → `sui/`

Syncs main with stage (already verified on `www-stage.ankr.com`).

## Test plan
- [x] Verified on stage
- [ ] Deploy to PROD and verify `https://www.ankr.com/docs/rpc-service/chains/chains-api/sui-grpc/` redirects to `sui/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)