### PR TITLE
docs(sui): JSON-RPC deprecation notice + per-service region info

### DIFF
--- a/pages/rpc-service/chains/chains-api/sui/grpc.mdx
+++ b/pages/rpc-service/chains/chains-api/sui/grpc.mdx
@@ -25,6 +25,16 @@ The Sui gRPC server fully supports server reflection, allowing tools like `grpcu
 
 For Premium users, pass your token via the `x-token` header (e.g., `-H "x-token: your-token"`).
 
+### Regions
+
+Sui gRPC services are deployed across multiple regions for low-latency access. Requests are routed to the closest healthy region automatically.
+
+| Service | Regions | High-level coverage |
+|---------|---------|---------------------|
+| Mainnet gRPC | Frankfurt, London, New York, Los Angeles, San Francisco, Singapore, Tokyo | EU, Americas, APAC |
+| Mainnet Archive gRPC | London, New York, Los Angeles, Singapore | EU, Americas, APAC |
+| Testnet gRPC | Frankfurt, New York, San Francisco, Singapore | EU, Americas, APAC |
+
 **Archive endpoint** — provides access to historical Sui data that standard full nodes may have pruned. It exposes the same `LedgerService` API, so you can use the same client code. Use it when querying older transactions, checkpoints, or objects that are no longer available on current nodes.
 
 ## Methods list

--- a/pages/rpc-service/chains/chains-api/sui/index.mdx
+++ b/pages/rpc-service/chains/chains-api/sui/index.mdx
@@ -6,6 +6,10 @@ import { Callout } from "components";
 
 <img src="/docs/build/chains-list/sui.png" className="responsive-pic" width="800" />
 
+<Callout type="warning">
+**JSON-RPC deprecation notice.** The Sui JSON-RPC interface is being deprecated and will be turned off at the **end of July 2026**, in line with the Sui Foundation's network-wide deprecation timeline. Please migrate existing integrations to **gRPC** (recommended for indexers and backend services) or **GraphQL** (recommended for frontends and analytics). See the [JSON-RPC page](/rpc-service/chains/chains-api/sui/json-rpc) for details.
+</Callout>
+
 <Callout type="tip">
 Available for [Freemium and Premium](/rpc-service/service-plans/#service-plans-comparison) users.
 </Callout>
@@ -22,8 +26,8 @@ Ankr provides multiple interfaces for interacting with Sui — JSON-RPC, gRPC, a
 
 | Interface | Network | Endpoint | Auth |
 |-----------|---------|----------|------|
-| JSON-RPC | Mainnet | `https://rpc.ankr.com/sui` | Token for Premium |
-| JSON-RPC | Testnet | `https://rpc.ankr.com/sui_testnet` | Token for Premium |
+| JSON-RPC *(deprecated, sunset end of July 2026)* | Mainnet | `https://rpc.ankr.com/sui` | Token for Premium |
+| JSON-RPC *(deprecated, sunset end of July 2026)* | Testnet | `https://rpc.ankr.com/sui_testnet` | Token for Premium |
 | gRPC | Mainnet | `sui.grpc.ankr.com:443` | `x-token` header for Premium |
 | gRPC | Testnet | `sui-testnet.grpc.ankr.com:443` | `x-token` header for Premium |
 | gRPC Archive | Mainnet | `archive.sui.grpc.ankr.com:443` | `x-token` header for Premium |
@@ -33,11 +37,29 @@ For Premium endpoints, append your token to the URL (for HTTP-based APIs) or pas
 
 ---
 
+## Regions
+
+Sui gRPC services are deployed across multiple regions for low-latency access. Requests are routed to the closest healthy region automatically.
+
+| Service | High-level coverage |
+|---------|---------------------|
+| Mainnet gRPC | EU, Americas, APAC |
+| Mainnet Archive gRPC | EU, Americas, APAC |
+| Testnet gRPC | EU, Americas, APAC |
+
+See the [gRPC page](/rpc-service/chains/chains-api/sui/grpc#regions) for the full list of cities per service.
+
+---
+
 ## Interfaces
 
-### JSON-RPC
+### JSON-RPC *(deprecated)*
 
-The standard [JSON-RPC 2.0](https://www.jsonrpc.org/specification) interface for reading blockchain data and sending transactions. This is the most widely used API for Sui dApp development.
+<Callout type="warning">
+Sunset at **end of July 2026**. Migrate existing integrations to gRPC or GraphQL.
+</Callout>
+
+The standard [JSON-RPC 2.0](https://www.jsonrpc.org/specification) interface for reading blockchain data and sending transactions. Historically the most common entry point for Sui dApps; superseded by gRPC and GraphQL going forward.
 
 [View JSON-RPC methods →](/rpc-service/chains/chains-api/sui/json-rpc)
 
@@ -66,7 +88,7 @@ Use the Archive endpoint when you need to query older transactions, checkpoints,
 ## Getting started
 
 1. **Get your API token** — Sign up at [ankr.com/rpc](https://www.ankr.com/rpc/sui) to get a Premium token, or use the public endpoints without authentication.
-2. **Choose your interface** — Pick JSON-RPC, gRPC, or GraphQL based on your use case.
+2. **Choose your interface** — Pick gRPC or GraphQL based on your use case (JSON-RPC is deprecated; see notice above).
 3. **Connect** — Use the endpoints from the table above with your preferred client library or tool.
 
 Official Sui links: [Website](https://sui.io/), [Docs](https://docs.sui.io/), [GitHub](https://github.com/MystenLabs)

--- a/pages/rpc-service/chains/chains-api/sui/json-rpc.mdx
+++ b/pages/rpc-service/chains/chains-api/sui/json-rpc.mdx
@@ -1,15 +1,24 @@
 import { Callout } from "components";
 
-# Sui
+# Sui JSON-RPC *(deprecated)*
 <br/>
 
 <img src="/docs/build/chains-list/sui.png" className="responsive-pic" width="800" />
+
+<Callout type="warning">
+**Deprecation notice.** The Sui JSON-RPC interface is being deprecated and will be turned off at the **end of July 2026**, in line with the Sui Foundation's network-wide deprecation timeline. Please migrate existing integrations to:
+
+- **[gRPC](/rpc-service/chains/chains-api/sui/grpc)** — recommended for indexers, backend services, and most dApp use cases.
+- **[GraphQL](/rpc-service/chains/chains-api/sui/graphql)** — recommended for frontends, dashboards, and analytics tools.
+
+This page is preserved for reference until the sunset date.
+</Callout>
 
 > Sui API is available on [Web3 API platform](https://www.ankr.com/rpc/sui).
 
 *Sui* is the first permissionless Layer 1 blockchain designed from the ground up to enable creators and developers to build experiences that cater to the next billion users in Web3. Sui is horizontally scalable to support a wide range of application development with unrivaled speed at low cost.
 
-In order for your Web3 application to interact with Sui — either by reading blockchain data or sending transactions to the network — it must connect to a Sui node. Developers interact with the blockchain using the methods provided by the API.
+In order for your Web3 application to interact with Sui — either by reading blockchain data or sending transactions to the network — it must connect to a Sui node. Historically, Sui developers have used JSON-RPC for this; going forward we recommend gRPC or GraphQL (see the deprecation notice above).
 
 The API interaction follows the [JSON-RPC](https://www.jsonrpc.org/specification) which is a stateless, light-weight remote procedure call (RPC) protocol. It defines several data structures and the rules around their processing. It is transport agnostic in that the concepts can be used within the same process, over sockets, over HTTP, or in other message-passing environments. It uses JSON (RFC 4627) as data format.
 


### PR DESCRIPTION
## Summary

Update Sui docs in response to a request from the Sui Foundation (Slack thread, message from Di Pearson on 2026-04-26):

1. **Add a deprecation notice** for the Sui JSON-RPC interface — sunset at the **end of July 2026**, in line with the Sui Foundation's network-wide deprecation timeline. Encourage migration to gRPC (backend / indexers) or GraphQL (frontends / analytics).
2. **Add high-level region info per service** so devs in different geos can pick the right entry point.

## Files changed

- `pages/rpc-service/chains/chains-api/sui/index.mdx`
  - Top-of-page warning Callout with the deprecation notice and migration pointer.
  - "deprecated, sunset end of July 2026" tag added to the two JSON-RPC rows of the Endpoints table.
  - New `## Regions` section after the Endpoints table — high-level coverage (EU, Americas, APAC) per service.
  - "JSON-RPC" interface section heading marked `*(deprecated)*` with an inline sunset Callout. Removed the "This is the most widely used API for Sui dApp development" sentence (specifically called out in the Foundation's follow-up).
  - "Getting started" step 2 updated to point devs at gRPC/GraphQL.

- `pages/rpc-service/chains/chains-api/sui/json-rpc.mdx`
  - H1 changed to `Sui JSON-RPC *(deprecated)*`.
  - Prominent warning Callout at the top with migration links to gRPC and GraphQL pages.
  - One-line tweak below the JSON-RPC paragraph to redirect new readers to gRPC/GraphQL.
  - The full method reference is preserved unchanged for existing integrations until sunset.

- `pages/rpc-service/chains/chains-api/sui/grpc.mdx`
  - New `### Regions` table after the Endpoints table — actual cities per service (Mainnet, Archive, Testnet) plus high-level coverage. Region list is per the deployment confirmed by Mike on 2026-03-27.

## Why now

The Foundation flagged on 2026-04-26 that JSON-RPC is still described as "the most widely used API for Sui dApp development" on the live page. This PR removes that framing and brings the page in line with the deprecation timeline.

## Test plan

- [ ] Preview build renders the warning Callouts correctly on `/rpc-service/chains/chains-api/sui/` and `/rpc-service/chains/chains-api/sui/json-rpc`.
- [ ] Anchor `#regions` on the gRPC page resolves correctly from the Overview link.
- [ ] No broken internal links introduced.
- [ ] Sui Foundation contact (Di Pearson) confirms the wording is acceptable before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
