### PR TITLE
docs(kite): add Kite AI mainnet chain page and chains-list entry

### DIFF
--- a/pages/rpc-service/chains/chains-api/_meta.json
+++ b/pages/rpc-service/chains/chains-api/_meta.json
@@ -40,6 +40,7 @@
   "kaia": "Kaia",
   "kava": "Kava",
   "kinto": "Kinto",
+  "kite": "Kite AI",
   "kusama": "Kusama",
   "linea": "Linea",
   "mantle": "Mantle",

--- a/pages/rpc-service/chains/chains-api/kite.mdx
+++ b/pages/rpc-service/chains/chains-api/kite.mdx
@@ -1,0 +1,2040 @@
+import { Callout } from "components";
+
+# Kite AI
+<br/>
+
+<img src="/docs/build/chains-list/kite.png" className="responsive-pic" width="800" />
+
+> Kite AI API is available on [Web3 API platform](https://www.ankr.com/rpc/kite).
+
+*Kite AI* is the first AI payment blockchain, providing foundational infrastructure that empowers autonomous agents to operate and transact with identity, payment, and verification. The network enables AI agents to discover and pay for services autonomously through features like funded wallets, scoped spending sessions, and service discovery, all while maintaining user control.
+
+In order for your Web3 application to interact with Kite AI — either by reading blockchain data or sending transactions to the network — it must connect to a Kite AI node. Developers interact with the blockchain using the methods provided by the API.
+
+The API interaction follows the [JSON-RPC](https://www.jsonrpc.org/specification) which is a stateless, light-weight remote procedure call (RPC) protocol. It defines several data structures and the rules around their processing. It is transport agnostic in that the concepts can be used within the same process, over sockets, over HTTP, or in other message-passing environments. It uses JSON (RFC 4627) as data format.
+
+---
+
+## Methods supported
+<br/>
+
+  * [`web3_clientVersion`](/rpc-service/chains/chains-api/kite/#web3_clientversion) — returns the current client version.
+  * [`web3_sha3`](/rpc-service/chains/chains-api/kite/#web3_sha3) — returns Keccak-256 (not the standardized SHA3-256) of the given data.
+  * [`net_version`](/rpc-service/chains/chains-api/kite/#net_version) — returns the current network ID.
+  * [`net_listening`](/rpc-service/chains/chains-api/kite/#net_listening) — returns true if client is actively listening for network connections.
+  * [`eth_syncing`](/rpc-service/chains/chains-api/kite/#eth_syncing) — returns data on the sync status or false.
+  * [`eth_gasPrice`](/rpc-service/chains/chains-api/kite/#eth_gasprice) — returns the current price per gas in wei.
+  * [`eth_accounts`](/rpc-service/chains/chains-api/kite/#eth_accounts) — returns a list of addresses owned by client.
+  * [`eth_blockNumber`](/rpc-service/chains/chains-api/kite/#eth_blocknumber) — returns the number of most recent block.
+  * [`eth_getBalance`](/rpc-service/chains/chains-api/kite/#eth_getbalance) — returns the balance of the account specified by address.
+  * [`eth_getStorageAt`](/rpc-service/chains/chains-api/kite/#eth_getstorageat) — returns the value from a storage position at an address specified.
+  * [`eth_getTransactionCount`](/rpc-service/chains/chains-api/kite/#eth_gettransactioncount) — returns the number of transactions sent from an address.
+  * [`eth_getBlockTransactionCountByHash`](/rpc-service/chains/chains-api/kite/#eth_getblocktransactioncountbyhash) — returns the number of transactions in a block specified by block hash.
+  * [`eth_getBlockTransactionCountByNumber`](/rpc-service/chains/chains-api/kite/#eth_getblocktransactioncountbynumber) — returns the number of transactions in the block specified by number.
+  * [`eth_getUncleCountByBlockHash`](/rpc-service/chains/chains-api/kite/#eth_getunclecountbyblockhash) — returns the number of uncles in a block specified by block hash.
+  * [`eth_getUncleCountByBlockNumber`](/rpc-service/chains/chains-api/kite/#eth_getunclecountbyblocknumber) — returns the number of uncles in a block specified by block number.
+  * [`eth_getCode`](/rpc-service/chains/chains-api/kite/#eth_getcode) — returns code at an address specified.
+  * [`eth_sendRawTransaction`](/rpc-service/chains/chains-api/kite/#eth_sendrawtransaction) — creates a new message call transaction or a contract creation for signed transactions.
+  * [`eth_call`](/rpc-service/chains/chains-api/kite/#eth_call) — executes a new message call immediately without creating a transaction on the blockchain.
+  * [`eth_estimateGas`](/rpc-service/chains/chains-api/kite/#eth_estimategas) — generates and returns an estimate of how much gas is necessary to allow the transaction to complete.
+  * [`eth_getBlockByHash`](/rpc-service/chains/chains-api/kite/#eth_getblockbyhash) — returns information for the block specified by block hash.
+  * [`eth_getBlockByNumber`](/rpc-service/chains/chains-api/kite/#eth_getblockbynumber) — returns information for the block specified by block number.
+  * [`eth_getTransactionByHash`](/rpc-service/chains/chains-api/kite/#eth_gettransactionbyhash) — returns information on a transaction specified by transaction hash.
+  * [`eth_getTransactionByBlockHashAndIndex`](/rpc-service/chains/chains-api/kite/#eth_gettransactionbyblockhashandindex) — returns information on a transaction specified by block hash and transaction index position.
+  * [`eth_getTransactionByBlockNumberAndIndex`](/rpc-service/chains/chains-api/kite/#eth_gettransactionbyblocknumberandindex) — returns information on a transaction by block number and transaction index position.
+  * [`eth_getTransactionReceipt`](/rpc-service/chains/chains-api/kite/#eth_gettransactionreceipt) — returns the receipt of a transaction by transaction hash.
+  * [`eth_getUncleByBlockHashAndIndex`](/rpc-service/chains/chains-api/kite/#eth_getunclebyblockhashandindex) — returns information about an uncle of a block by hash and uncle index position.
+  * [`eth_getUncleByBlockNumberAndIndex`](/rpc-service/chains/chains-api/kite/#eth_getunclebyblocknumberandindex) — returns information about an uncle of a block by number and uncle index position.
+  * [`eth_getLogs`](/rpc-service/chains/chains-api/kite/#eth_getlogs) — returns logs matching the parameters specified.
+
+**Premium-only methods**:
+
+  * [`debug_traceBlockByHash`](/rpc-service/chains/chains-api/kite/#debug_traceblockbyhash) — traces the execution of all transactions within a block specified by hash.
+  * [`debug_traceBlockByNumber`](/rpc-service/chains/chains-api/kite/#debug_traceblockbynumber) — traces the execution of all transactions within a block specified by number.
+  * [`debug_traceBlock`](/rpc-service/chains/chains-api/kite/#debug_traceblock) — traces the execution of all transactions within a block.
+
+---
+
+## `web3_clientVersion`
+
+> Returns the current client version.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required): None.
+
+### Returns
+<br/>
+
+  * `<string>`: the current client version.
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet \
+-H 'Content-Type: application/json' \
+-d '{
+      "jsonrpc": "2.0",
+      "method": "web3_clientVersion",
+      "params": [],
+      "id": 1
+    }'
+```
+
+### Response example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "result": "Geth/v1.13.8-stable/linux-amd64/go1.21.6",
+    "id": 1
+}
+```
+
+---
+
+## `web3_sha3`
+
+> Returns Keccak-256 (not the standardized SHA3-256) of the given data.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required):
+
+    * `<string>` (data): the data to convert into a SHA3 hash.
+
+### Returns
+<br/>
+
+  * `<string>` (data): the SHA3 result of the given string.
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet \
+-H 'Content-Type: application/json' \
+-d '{
+      "jsonrpc": "2.0",
+      "method": "web3_sha3",
+      "params": ["0x68656c6c6f20776f726c64"],
+      "id": 1
+    }'
+```
+
+### Response example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": "0x47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad"
+}
+```
+
+---
+
+## `net_version`
+
+> Returns the current network ID.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required): None.
+
+### Returns
+<br/>
+
+  * `<string>`: the current network ID.
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet \
+-H 'Content-Type: application/json' \
+-d '{
+      "jsonrpc": "2.0",
+      "method": "net_version",
+      "params": [],
+      "id": 1
+    }'
+```
+
+### Response example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": "2366"
+}
+```
+
+---
+
+## `net_listening`
+
+> Returns `true` if client is actively listening for network connections.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required): None.
+
+### Returns
+<br/>
+
+  * `<boolean>`: `true` when listening, otherwise `false`.
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet \
+-H 'Content-Type: application/json' \
+-d '{
+      "jsonrpc": "2.0",
+      "method": "net_listening",
+      "params": [],
+      "id": 1
+    }'
+```
+
+### Response example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": true
+}
+```
+
+---
+
+## `eth_syncing`
+
+> Returns an object with data about the sync status or false.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required): None.
+
+### Returns
+<br/>
+
+  * `<object>`|`<boolean>`: an object with sync status data or `false`, when not syncing:
+    * `startingBlock` (quantity): the block at which the import started (will only be reset, after the sync reached its head).
+    * `currentBlock` (quantity): the current block, same as `eth_blockNumber`.
+    * `highestBlock` (quantity): the estimated highest block.
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet \
+-H 'Content-Type: application/json' \
+-d '{
+      "jsonrpc": "2.0",
+      "method": "eth_syncing",
+      "params": [],
+      "id": 1
+    }'
+```
+
+### Response example (syncing)
+
+```json
+{
+    "id": 1,
+    "jsonrpc": "2.0",
+    "result": {
+        "startingBlock": "0x384",
+        "currentBlock": "0x386",
+        "highestBlock": "0x454"
+    }
+}
+```
+
+### Response example (not syncing)
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": false
+}
+```
+
+---
+
+## `eth_gasPrice`
+
+> Returns the current price per gas in wei.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required): None.
+
+### Returns
+<br/>
+
+  * `<string>` (quantity): the current gas price in wei.
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet \
+-H 'Content-Type: application/json' \
+-d '{
+      "jsonrpc": "2.0",
+      "method": "eth_gasPrice",
+      "params": [],
+      "id": 1
+    }'
+```
+
+### Response example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": "0x3"
+}
+```
+
+---
+
+## `eth_accounts`
+
+> Returns a list of addresses owned by client.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required): None.
+
+### Returns
+<br/>
+
+  * `<array>` (string; data, 20 bytes): addresses owned by the client.
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet \
+-H 'Content-Type: application/json' \
+-d '{
+      "jsonrpc": "2.0",
+      "method": "eth_accounts",
+      "params": [],
+      "id": 1
+    }'
+```
+
+### Response example
+
+```json
+{
+    "id": 1,
+    "jsonrpc": "2.0",
+    "result": []
+}
+```
+
+---
+
+## `eth_blockNumber`
+
+> Returns the number of most recent block.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required): None.
+
+### Returns
+<br/>
+
+  * `<string>` (quantity): the current block number the client is on.
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet \
+-H 'Content-Type: application/json' \
+-d '{
+      "jsonrpc": "2.0",
+      "method": "eth_blockNumber",
+      "params": [],
+      "id": 1
+    }'
+```
+
+### Response example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": "0xa2acc"
+}
+```
+
+---
+
+## `eth_getBalance`
+
+> Returns the balance of the account specified by address.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required):
+
+    1. `<string>` (data, 20 bytes): an address to check for balance.
+    2. `<string>` (quantity|tag): either the hex value of a _block number_ or one of the following _block tags_:
+        * `earliest`: the lowest numbered block available on the client.
+        * `finalized`: the most recent crypto-economically secure block; cannot be re-orged outside of manual intervention driven by community coordination.
+        * `safe`: the most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions.
+        * `latest`: the most recent block in the canonical chain observed by the client; this block can be re-orged out of the canonical chain even under healthy/normal conditions.
+        * `pending`: a sample next block built by the client on top of the `latest` and containing the set of transactions usually taken from local mempool. In other words, it is the block that has not been mined yet.
+
+### Returns
+<br/>
+
+  * `<string>` (quantity): the current balance in wei.
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet \
+-H 'Content-Type: application/json' \
+-d '{
+      "jsonrpc": "2.0",
+      "method": "eth_getBalance",
+      "params": ["0x904D60501D8B8E904673B3E0BCC7E6aE6e57A195", "latest"],
+      "id": 1
+    }'
+```
+
+### Response example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": "0xe3320b81758ef"
+}
+```
+
+---
+
+## `eth_getStorageAt`
+
+> Returns the value from a storage position at an address specified.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required):
+
+    1. `<string>` (data, 20 bytes): an address of the storage (hex encoded).
+    2. `<string>` (quantity): a slot position in the storage (hex encoded unsigned integer).
+    3. `<string>` (quantity|tag): either the hex value of a _block number_ or one of the following _block tags_:
+
+        * `earliest`: the lowest numbered block available on the client.
+        * `finalized`: the most recent crypto-economically secure block; cannot be re-orged outside of manual intervention driven by community coordination.
+        * `safe`: the most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions.
+        * `latest`: the most recent block in the canonical chain observed by the client; this block can be re-orged out of the canonical chain even under healthy/normal conditions.
+        * `pending`: a sample next block built by the client on top of the `latest` and containing the set of transactions usually taken from local mempool. In other words, it is the block that has not been mined yet.
+
+### Returns
+<br/>
+
+  * `<string>` (data): the value at this storage position.
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet \
+-H 'Content-Type: application/json' \
+-d '{
+      "jsonrpc": "2.0",
+      "method": "eth_getStorageAt",
+      "params": ["0x904D60501D8B8E904673B3E0BCC7E6aE6e57A195", "0x0", "latest"],
+      "id": 1
+    }'
+```
+
+### Response example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": "0x0000000000000000000000000000000000000000000000000000000000000000"
+}
+```
+
+---
+
+## `eth_getTransactionCount`
+
+> Returns the number of transactions sent from an address.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required):
+
+    1. `<string>` (data, 20 bytes): an address.
+    2. `<string>` (quantity|tag): either the hex value of a _block number_ or one of the following _block tags_:
+
+        * `earliest`: the lowest numbered block available on the client.
+        * `finalized`: the most recent crypto-economically secure block; cannot be re-orged outside of manual intervention driven by community coordination.
+        * `safe`: the most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions.
+        * `latest`: the most recent block in the canonical chain observed by the client; this block can be re-orged out of the canonical chain even under healthy/normal conditions.
+        * `pending`: a sample next block built by the client on top of the `latest` and containing the set of transactions usually taken from local mempool. In other words, it is the block that has not been mined yet.
+
+### Returns
+<br/>
+
+  * `<string>` (quantity): the number of transactions send from this address.
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet \
+-H 'Content-Type: application/json' \
+-d '{
+      "jsonrpc": "2.0",
+      "method": "eth_getTransactionCount",
+      "params": ["0x904D60501D8B8E904673B3E0BCC7E6aE6e57A195", "safe"],
+      "id": 1
+    }'
+```
+
+### Response example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": "0x4"
+}
+```
+
+---
+
+## `eth_getBlockTransactionCountByHash`
+
+> Returns the number of transactions in a block specified by block hash.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required):
+
+    1. `<string>` (data, 32 bytes): a block hash.
+
+### Returns
+<br/>
+
+  * `<string>` (quantity): the number of transactions in this block.
+
+### Request example:
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet \
+-H 'Content-Type: application/json' \
+-d '{
+      "jsonrpc": "2.0",
+      "method": "eth_getBlockTransactionCountByHash",
+      "params": ["0xc5a82afa5fda0fad21f573220ae47384da3aa122735b75e92cdd1fda6210400e"],
+      "id": 1
+    }'
+```
+
+### Response example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": "0x50"
+}
+```
+
+---
+
+## `eth_getBlockTransactionCountByNumber`
+
+> Returns the number of transactions in the block specified by number.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required):
+
+    1. `<string>` (quantity|tag): either the hex value of a _block number_ or one of the following _block tags_:
+        * `earliest`: the lowest numbered block available on the client.
+        * `finalized`: the most recent crypto-economically secure block; cannot be re-orged outside of manual intervention driven by community coordination.
+        * `safe`: the most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions.
+        * `latest`: the most recent block in the canonical chain observed by the client; this block can be re-orged out of the canonical chain even under healthy/normal conditions.
+        * `pending`: a sample next block built by the client on top of the `latest` and containing the set of transactions usually taken from local mempool. In other words, it is the block that has not been mined yet.
+
+### Returns
+<br/>
+
+  * `<string>` (quantity): the number of transactions in this block.
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet \
+-H 'Content-Type: application/json' \
+-d '{
+      "jsonrpc": "2.0",
+      "method": "eth_getBlockTransactionCountByNumber",
+      "params": ["0x9B407"],
+      "id": 1
+    }'
+```
+
+### Response example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": "0x50"
+}
+```
+
+---
+
+## `eth_getUncleCountByBlockHash`
+
+> Returns the number of uncles in a block specified by block hash.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required):
+
+    1. `<string>` (data, 32 bytes): a block hash.
+
+### Returns
+<br/>
+
+  * `<string>` (quantity): the number of uncles in this block.
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet \
+-H 'Content-Type: application/json' \
+-d '{
+      "jsonrpc": "2.0",
+      "method": "eth_getUncleCountByBlockHash",
+      "params": ["0xc5a82afa5fda0fad21f573220ae47384da3aa122735b75e92cdd1fda6210400e"],
+      "id": 1
+    }'
+```
+
+### Response example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": "0x0"
+}
+```
+
+---
+
+## `eth_getUncleCountByBlockNumber`
+
+> Returns the number of uncles in a block specified by block number.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required):
+
+    1. `<string>` (quantity|tag): either the hex value of a _block number_ or one of the following _block tags_:
+        * `earliest`: the lowest numbered block available on the client.
+        * `finalized`: the most recent crypto-economically secure block; cannot be re-orged outside of manual intervention driven by community coordination.
+        * `safe`: the most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions.
+        * `latest`: the most recent block in the canonical chain observed by the client; this block can be re-orged out of the canonical chain even under healthy/normal conditions.
+        * `pending`: a sample next block built by the client on top of the `latest` and containing the set of transactions usually taken from local mempool. In other words, it is the block that has not been mined yet.
+
+### Returns
+<br/>
+
+  * `<string>` (quantity): the number of uncles in this block.
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet \
+-H 'Content-Type: application/json' \
+-d '{
+      "jsonrpc": "2.0",
+      "method": "eth_getUncleCountByBlockNumber",
+      "params": ["0xA2ACA"],
+      "id": 1
+    }'
+```
+
+### Response example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": "0x0"
+}
+```
+
+---
+
+## `eth_getCode`
+
+> Returns code at a given address.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required):
+
+    1. `<string>` (data, 20 bytes): an address to get the code from.
+    2. `<string>` (quantity|tag): either the hex value of a _block number_ or one of the following _block tags_:
+        * `earliest`: the lowest numbered block available on the client.
+        * `finalized`: the most recent crypto-economically secure block; cannot be re-orged outside of manual intervention driven by community coordination.
+        * `safe`: the most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions.
+        * `latest`: the most recent block in the canonical chain observed by the client; this block can be re-orged out of the canonical chain even under healthy/normal conditions.
+        * `pending`: a sample next block built by the client on top of the `latest` and containing the set of transactions usually taken from local mempool. In other words, it is the block that has not been mined yet.
+
+### Returns
+<br/>
+
+  * `<string>` (data): the code from the given address.
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet \
+-H 'Content-Type: application/json' \
+-d '{
+      "jsonrpc": "2.0",
+      "method": "eth_getCode",
+      "params": ["0x904D60501D8B8E904673B3E0BCC7E6aE6e57A195", "0x1"],
+      "id": 1
+    }'
+```
+
+### Response example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": "0x"
+}
+```
+
+---
+
+## `eth_sendRawTransaction`
+
+> Creates new message call transaction or a contract creation for signed transactions.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required):
+
+    1. `<string>` (data): the signed transaction data.
+
+### Returns
+<br/>
+
+  * `<string>` (data, 32 bytes): the transaction hash, or the zero hash if the transaction is not yet available.
+
+Use [eth_getTransactionReceipt](/rpc-service/chains/chains-api/kite/#eth_gettransactionreceipt) to get the contract address, after the transaction was mined, when you created a contract.
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet \
+-H 'Content-Type: application/json' \
+-d '{
+    "jsonrpc": "2.0",
+    "method": "eth_sendRawTransaction",
+    "params": ["0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"],
+    "id": 1
+}'
+```
+
+### Response example
+
+```json
+{
+    "id": 1,
+    "jsonrpc": "2.0",
+    "result": "0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331"
+}
+```
+
+---
+
+## `eth_call`
+
+> Executes a new message call immediately without creating a transaction on the blockchain.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required):
+
+    1. `<object>` (hex encoded): the transaction object:
+        * `from` (string; data, 20 bytes; optional): the address the transaction is sent from.
+        * `to` (string; data, 20 bytes): the address the transaction is directed to.
+        * `gas` (string; quantity; optional): the gas provided for the transaction execution. `eth_call` consumes zero gas, but this parameter may be needed by some executions.
+        * `gasPrice` (string; quantity; optional): the gas price willing to be paid by the sender in wei.
+        * `value` (string; quantity; optional): the value sent with this transaction, in wei.
+        * `data` (string; data; optional): the hash of the method signature and encoded parameters.
+
+    2. `<string>` (quantity|tag): either the hex value of a _block number_ or one of the following _block tags_:
+        * `earliest`: the lowest numbered block available on the client.
+        * `finalized`: the most recent crypto-economically secure block; cannot be re-orged outside of manual intervention driven by community coordination.
+        * `safe`: the most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions.
+        * `latest`: the most recent block in the canonical chain observed by the client; this block can be re-orged out of the canonical chain even under healthy/normal conditions.
+        * `pending`: a sample next block built by the client on top of the `latest` and containing the set of transactions usually taken from local mempool. In other words, it is the block that has not been mined yet.
+
+### Returns
+<br/>
+
+  * `<string>` (hex encoded bytes): the return value of executed contract.
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet \
+-H 'Content-Type: application/json' \
+-d '{
+    "jsonrpc": "2.0",
+    "method": "eth_call",
+    "params": [{"from":null,"to":"0x904D60501D8B8E904673B3E0BCC7E6aE6e57A195","data":"0x70a082310000000000000000000000006E0d01A76C3Cf4288372a29124A26D4353EE51BE"}, "latest"],
+    "id": 1
+}'
+```
+
+### Response example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": "0x"
+}
+```
+
+---
+
+## `eth_estimateGas`
+
+> Generates and returns an estimate of how much gas is necessary to allow the transaction to complete.
+
+The transaction will not be added to the blockchain. Note that the estimate may be significantly more than the amount of gas actually used by the transaction, for a variety of reasons including EVM mechanics and node performance.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required):
+
+    1. `<object>` (hex encoded): the transaction object:
+        * `from` (string; data, 20 bytes; optional): the address the transaction is sent from.
+        * `to` (string; data, 20 bytes; optional): the address the transaction is directed to.
+        * `gas` (string; quantity; optional): the gas provided for the transaction execution. `eth_call` consumes zero gas, but this parameter may be needed by some executions.
+        * `gasPrice` (string; quantity; optional): the gas price willing to be paid by the sender in wei.
+        * `value` (string; quantity; optional): the value sent with this transaction, in wei.
+        * `data` (string; data; optional): the hash of the method signature and encoded parameters.
+
+    2. `<string>` (quantity|tag; optional): either a HEX value of a *block number* or one of the following *block tags*:
+        * `earliest`: the lowest numbered block available on the client.
+        * `finalized`: the most recent crypto-economically secure block; cannot be re-orged outside of manual intervention driven by community coordination.
+        * `safe`: the most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions.
+        * `latest`: the most recent block in the canonical chain observed by the client; this block can be re-orged out of the canonical chain even under healthy/normal conditions.
+        * `pending`: a sample next block built by the client on top of the `latest` and containing the set of transactions usually taken from local mempool. In other words, it is the block that has not been mined yet.
+
+### Returns
+<br/>
+
+  * `<string>` (quantity): the amount of gas used.
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet \
+-H 'Content-Type: application/json' \
+-d '{
+    "jsonrpc": "2.0",
+    "method": "eth_estimateGas",
+    "params": [{"from":null,"to":"0x904D60501D8B8E904673B3E0BCC7E6aE6e57A195","data":"0x70a082310000000000000000000000006E0d01A76C3Cf4288372a29124A26D4353EE51BE"}, "latest"],
+    "id": 1
+}'
+```
+
+### Response example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": "0x545e"
+}
+```
+
+---
+
+## `eth_getBlockByHash`
+
+> Returns information for the block specified by block hash.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required):
+
+    1. `<string>` (data, 32 bytes): the block hash.
+    2. `<boolean>`: if `true` it returns the full transaction objects, if `false` — only the hashes of the transactions.
+
+### Returns
+<br/>
+
+  * `<object>`: a block object, or null when no block was found:
+      * `number` (string; quantity): the block number; null when it's a pending block.
+      * `hash` (string; data, 32 bytes): the hash of the block; null when it's a pending block.
+      * `parentHash` (string; data, 32 bytes): the hash of the parent block.
+      * `nonce` (string; data, 8 bytes): the hash of the generated proof-of-work; null when it's a pending block.
+      * `sha3Uncles` (string; data, 32 bytes): SHA3 of the uncles data in the block.
+      * `logsBloom` (string; data, 256 bytes): the bloom filter for the logs of the block. null when its pending block.
+      * `transactionsRoot` (string; data, 32 bytes): the root of the transaction trie of the block.
+      * `stateRoot` (string; data, 32 bytes): the root of the final state trie of the block.
+      * `receiptsRoot` (string; data, 32 bytes): the root of the receipts trie of the block.
+      * `miner` (string; data, 20 bytes): the address of the beneficiary to whom the mining rewards were given.
+      * `difficulty` (string; quantity): the difficulty for this block.
+      * `totalDifficulty` (string; quantity): the total difficulty of the chain until this block.
+      * `extraData` (string; data): the **extra data** field of this block.
+      * `size` (string; quantity): the size of this block in bytes.
+      * `gasLimit` (string; quantity): the maximum gas allowed in this block.
+      * `gasUsed` (string; quantity): the total used gas by all transactions in this block.
+      * `timestamp` (string; quantity): the unix timestamp for when the block was collated.
+      * `transactions` (array of strings): an array of transaction objects, or 32 bytes transaction hashes depending on the last given parameter.
+      * `uncles` (array of strings): an array of uncle hashes.
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet \
+-H 'Content-Type: application/json' \
+-d '{
+      "jsonrpc": "2.0",
+      "method": "eth_getBlockByHash",
+      "params": ["0x256ac8ce2844b87c69895aba06138ffaa6759433306a7d86e6385b5b42b1f371", false],
+      "id": 1
+    }'
+```
+
+### Response example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "baseFeePerGas": "0x1",
+        "difficulty": "0x0",
+        "extraData": "0x302e31382e302d64657600000000000000000000000000000000000000000000",
+        "gasLimit": "0xe8b250",
+        "gasUsed": "0x4ab5d3",
+        "hash": "0x256ac8ce2844b87c69895aba06138ffaa6759433306a7d86e6385b5b42b1f371",
+        "logsBloom": "0x000802200010000000100800000000000401000300000000002082018200000000001000000001000500220010002000000000000001200100200000002020420000400440000008002001091000000000400100800010000000008080028080020040000280011100080002082008006040000000010000000001108008000000041000000004d8000120001002000000001041001000042000000101000000022000000200100000200000000800000501000001000022042000884040000000204002008040000101000001002000000800000000000000000008c0002000201028088080400208002000010000200000280410010c518000000002001200",
+        "miner": "0xe1e210594771824dad216568b91c9cb4ceed361c",
+        "mixHash": "0x76a924a163d521a6f218cd6d7c5c034a8ad4d20c079bd707fdfe6c858526b4e6",
+        "nonce": "0x0000000000000000",
+        "number": "0xa2aca",
+        "parentHash": "0xfc3f6a958d2eb00aa3bf763c85abb609bfb876457edf366b1b1fe4b20b3b5392",
+        "receiptsRoot": "0x23724f5f91a8cef90f20e39415c54bdf1e2ac43cf99c86f78e086ab1c0e5ceca",
+        "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "size": "0x563b",
+        "stateRoot": "0x3fc853c7cb77d07d4f5c8a26e7ef3e903f9089cf9cc56f76a1f7ef2af7e17e07",
+        "timestamp": "0x6602cfc4",
+        "totalDifficulty": "0x0",
+        "transactions": [
+            "0x7ccf86b2b79f7021cf752124519b3d95bdae519db2d90092551d258617c34bea",
+            "0xb5136d9f0626c0c4667d251c56d0e28b82169f655e73bc929664b21cea8b2b14",
+            "0xc5b91e76c221d360cc99d5a7038cb9ddef2e86172922d35690fa44a0ba27a2a4",
+            "0xd39c20048d4424dd83db4ae2350426ea929360b4cc262137e0f463a1b5f9946f",
+            "0x2d2b76942b7332043a9e4d7b9aa195143097a35fbf9afa7c59d19b624a64022f",
+            "0xfee38b6dc9eb985e7527c1bc2dc087a0c000df6935738351005d43e1cdb72060",
+            "0x1acf9b60fd7bdee66fd22f9e9552829a4f5a4ce0ac582fc25c4e972db4ae2d8a",
+            "0x0a042b9b9d408d0c95e1379bde81acbdbd9df0176ed20998ede947a47b044250",
+            "0xd1b605106868876f892cb887a415b55650a03100682d2b3c5be5ff8ed85129db",
+            "0xd23408ab38cf6f234f7a1d8f2d142246e10ed92d98f436b342f18b9632eef5ee"
+        ],
+        "transactionsRoot": "0x91246983d28d6e5b84199617eb0fa683aaea059e93d366b46429e0e034f50a5c",
+        "uncles": [],
+        "withdrawals": [],
+        "withdrawalsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
+    }
+}
+```
+
+---
+
+## `eth_getBlockByNumber`
+
+> Returns information for the block specified by block number.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required):
+
+    1. `<string>` (quantity|tag): either the hex value of a *block number* or one of the following *block tags*:
+       * `earliest`: the lowest numbered block available on the client.
+       * `finalized`: the most recent crypto-economically secure block; cannot be re-orged outside of manual intervention driven by community coordination.
+       * `safe`: the most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions.
+       * `latest`: the most recent block in the canonical chain observed by the client; this block can be re-orged out of the canonical chain even under healthy/normal conditions.
+       * `pending`: a sample next block built by the client on top of the `latest` and containing the set of transactions usually taken from local mempool. In other words, it is the block that has not been mined yet.
+    2. `<boolean>`: if `true` it returns the full transaction objects, if `false` — only the hashes of the transactions.
+
+### Returns
+<br/>
+
+  * `<object>`: a block object, or null when no block was found:
+      * `number` (string; quantity): the block number; null when it's a pending block.
+      * `hash` (string; data, 32 bytes): the hash of the block; null when it's a pending block.
+      * `parentHash` (string; data, 32 bytes): the hash of the parent block.
+      * `nonce` (string; data, 8 bytes): the hash of the generated proof-of-work; null when it's a pending block.
+      * `sha3Uncles` (string; data, 32 bytes): SHA3 of the uncles data in the block.
+      * `logsBloom` (string; data, 256 bytes): the bloom filter for the logs of the block. null when its pending block.
+      * `transactionsRoot` (string; data, 32 bytes): the root of the transaction trie of the block.
+      * `stateRoot` (string; data, 32 bytes): the root of the final state trie of the block.
+      * `receiptsRoot` (string; data, 32 bytes): the root of the receipts trie of the block.
+      * `miner` (string; data, 20 bytes): the address of the beneficiary to whom the mining rewards were given.
+      * `difficulty` (string; quantity): the difficulty for this block.
+      * `totalDifficulty` (string; quantity): the total difficulty of the chain until this block.
+      * `extraData` (string; data): the **extra data** field of this block.
+      * `size` (string; quantity): the size of this block in bytes.
+      * `gasLimit` (string; quantity): the maximum gas allowed in this block.
+      * `gasUsed` (string; quantity): the total used gas by all transactions in this block.
+      * `timestamp` (string; quantity): the unix timestamp for when the block was collated.
+      * `transactions` (array of strings): an array of transaction objects, or 32 bytes transaction hashes depending on the last given parameter.
+      * `uncles` (array of strings): an array of uncle hashes.
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet \
+-H 'Content-Type: application/json' \
+-d '{
+      "jsonrpc": "2.0",
+      "method": "eth_getBlockByNumber",
+      "params": ["latest", true],
+      "id": 1
+    }'
+```
+
+### Response example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "baseFeePerGas": "0x1",
+        "difficulty": "0x0",
+        "extraData": "0x302e31382e302d64657600000000000000000000000000000000000000000000",
+        "gasLimit": "0xe8b250",
+        "gasUsed": "0x2aade",
+        "hash": "0xdd3bda432583d696083e2bac2167c3aa999dd0a18f70fa796c5ca44b576e1adc",
+        "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000002040000000000400000000000000000000000000000000000000000000000002000000000000000000000000000000000000200000000000000000000000000000000000100000000000000100000000000000000000000000000000000000000000002000000000000000000000000000020100000000000002000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000001000000",
+        "miner": "0xe1e210594771824dad216568b91c9cb4ceed361c",
+        "mixHash": "0xa17ef61063021597ee89e2ff5e610f895b09b550cebf6c24f0c7231ee9fcf41f",
+        "nonce": "0x0000000000000000",
+        "number": "0xa2b16",
+        "parentHash": "0xfeebb2da16ebbca6ff68ea2147363bba34e857ea787bdd01a5c0717b969bd9f4",
+        "receiptsRoot": "0x690387fda3d3a8d903f4de2eadb546fd799c01af642a66bd681c7ba7998ce8df",
+        "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "size": "0x3e8",
+        "stateRoot": "0xc8303658270b0ee6993841b6875f73c10cdab1a988263f071eb1a67561eccdbe",
+        "timestamp": "0x6602d1f8",
+        "totalDifficulty": "0x0",
+        "transactions": [
+            {
+                "blockHash": "0xdd3bda432583d696083e2bac2167c3aa999dd0a18f70fa796c5ca44b576e1adc",
+                "blockNumber": "0xa2b16",
+                "from": "0x0000777735367b36bc9b61c50022d9d0700db4ec",
+                "gas": "0x3d090",
+                "gasPrice": "0x1",
+                "maxFeePerGas": "0x1",
+                "maxPriorityFeePerGas": "0x0",
+                "hash": "0xb9a04b86082f007b1f51b565835979f9a83063042d89979053555ab3295fa626",
+                "input": "0xda69d3dbb62a06bd6f9a0a10496024008e0fa61adb990694f220ab489789e7431df2f3764624af72612a6dcea1d5ddfa6a0edba86be625adb1fdd55f90f13e23bb5946770000000000000000000000000000000000000000000000000000000000129f7c00000000000000000000000000000000000000000000000000000000003041ec",
+                "nonce": "0xa2b27",
+                "to": "0x1670080000000000000000000000000000010001",
+                "transactionIndex": "0x0",
+                "value": "0x0",
+                "type": "0x2",
+                "accessList": [],
+                "chainId": "0x93e",
+                "v": "0x1",
+                "r": "0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+                "s": "0x72f3bdd7e94da2c30cd06275a03e4774c1d4e68a9facc87e6754065ccec5ca56",
+                "yParity": "0x1"
+            }
+        ],
+        "transactionsRoot": "0x94b5ef81fca806c7edcdd8d2d1fdc6e63cbb90c547536f9ad770dd3a562d62d8",
+        "uncles": [],
+        "withdrawals": [],
+        "withdrawalsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
+    }
+}
+```
+
+---
+
+## `eth_getTransactionByHash`
+
+> Returns information on a transaction specified by transaction hash.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required):
+
+    1. `<string>` (data, 32 bytes): a transaction hash.
+
+### Returns
+<br/>
+
+  * `blockHash` (string; data, 32 bytes): a hash of the block containing the transaction; null when it's pending.
+  * `blockNumber` (string; quantity): a number of the block containing the transaction; null when it's pending.
+  * `from` (string; data, 20 bytes): an address of the sender.
+  * `gas` (string; quantity): the gas provided by the sender.
+  * `gasPrice` (string; quantity): the gas price provided by the sender in wei.
+  * `hash` (string; data, 32 bytes): the hash of the transaction.
+  * `input` (string; data): the data send along with the transaction.
+  * `nonce` (string; quantity): the number of transactions made by the sender prior to this one.
+  * `to` (string: data, 20 bytes): an address of the receiver: null when it's a contract creation transaction.
+  * `transactionIndex` (string; quantity): the transaction index position in the block; null when it's pending.
+  * `value` (string; quantity): the value transferred in wei.
+  * `v` (string; quantity): ECDSA recovery ID.
+  * `r` (string; quantity): ECDSA signature r.
+  * `s` (string; quantity): ECDSA signature s.
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet \
+-H 'Content-Type: application/json' \
+-d '{
+      "jsonrpc": "2.0",
+      "method": "eth_getTransactionByHash",
+      "params": ["0xf67b4d2caab1c16b6f292f7b220c09df038b7f38edcbe9e0915159817845ff9a"],
+      "id": 1
+    }'
+```
+
+### Response example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "blockHash": "0x256ac8ce2844b87c69895aba06138ffaa6759433306a7d86e6385b5b42b1f371",
+        "blockNumber": "0xa2aca",
+        "from": "0xf1a66ee4db3bfec6a4233bd10e587dacdae985a6",
+        "gas": "0x186a0",
+        "gasPrice": "0x59682f01",
+        "maxFeePerGas": "0x59682f01",
+        "maxPriorityFeePerGas": "0x59682f01",
+        "hash": "0xf67b4d2caab1c16b6f292f7b220c09df038b7f38edcbe9e0915159817845ff9a",
+        "input": "0x",
+        "nonce": "0x5c62",
+        "to": "0x904d60501d8b8e904673b3e0bcc7e6ae6e57a195",
+        "transactionIndex": "0x2c",
+        "value": "0x38d7ea4c68000",
+        "type": "0x2",
+        "accessList": [],
+        "chainId": "0x93e",
+        "v": "0x0",
+        "r": "0x9fdc95549372694cf157b5c53ffb9698a59f5738f384f1166ee16467a654cd22",
+        "s": "0x5de976d4d2beebff2419459f1fe4c0a034268ec98dbd7181a4f584a86a9e29d1",
+        "yParity": "0x0"
+    }
+}
+```
+
+---
+
+## `eth_getTransactionByBlockHashAndIndex`
+
+> Returns information on a transaction specified by block hash and transaction index position.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required):
+
+    1. `<string>` (data, 32 bytes): a block hash.
+    2. `<string>` (quantity): a transaction index position.
+
+### Returns
+<br/>
+
+  * `blockHash` (string; data, 32 bytes): a hash of the block containing the transaction; null when it's pending.
+  * `blockNumber` (string; quantity): a number of the block containing the transaction; null when it's pending.
+  * `from` (string; data, 20 bytes): an address of the sender.
+  * `gas` (string; quantity): the gas provided by the sender.
+  * `gasPrice` (string; quantity): the gas price provided by the sender in wei.
+  * `hash` (string; data, 32 bytes): the hash of the transaction.
+  * `input` (string; data): the data send along with the transaction.
+  * `nonce` (string; quantity): the number of transactions made by the sender prior to this one.
+  * `to` (string: data, 20 bytes): an address of the receiver: null when it's a contract creation transaction.
+  * `transactionIndex` (string; quantity): the transaction index position in the block; null when it's pending.
+  * `value` (string; quantity): the value transferred in wei.
+  * `v` (string; quantity): ECDSA recovery ID.
+  * `r` (string; quantity): ECDSA signature r.
+  * `s` (string; quantity): ECDSA signature s.
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet \
+-H 'Content-Type: application/json' \
+-d '{
+      "jsonrpc": "2.0",
+      "method": "eth_getTransactionByBlockHashAndIndex",
+      "params": ["0x256ac8ce2844b87c69895aba06138ffaa6759433306a7d86e6385b5b42b1f371", "0x1"],
+      "id": 1
+    }'
+```
+
+### Response example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "blockHash": "0x256ac8ce2844b87c69895aba06138ffaa6759433306a7d86e6385b5b42b1f371",
+        "blockNumber": "0xa2aca",
+        "from": "0x4e9267cdecf7668ad5bb963f51399d0daacaf948",
+        "gas": "0x1a4d4",
+        "gasPrice": "0xf8db9b8d",
+        "hash": "0xb5136d9f0626c0c4667d251c56d0e28b82169f655e73bc929664b21cea8b2b14",
+        "input": "0xa9059cbb0000000000000000000000004e9267cdecf7668ad5bb963f51399d0daacaf9480000000000000000000000000000000000000000000000000000000000000000",
+        "nonce": "0x8",
+        "to": "0x05f4539e5e34252f91bc479de77ae4c0bd030e66",
+        "transactionIndex": "0x1",
+        "value": "0x0",
+        "type": "0x0",
+        "chainId": "0x93e",
+        "v": "0x518e3",
+        "r": "0x7218b8f27cef7788804ebaee1e7a8d05848fc4ee7285a019e48db9972ae649f6",
+        "s": "0x79345ab4b155a801be7c684b3135674586b2dd652d24b87fd0821ca834c07feb"
+    }
+}
+```
+
+---
+
+## `eth_getTransactionByBlockNumberAndIndex`
+
+> Returns information on a transaction by block number and transaction index position.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required):
+
+    1. `<string>` (quantity|tag): either the hex value of a _block number_ or one of the following _block tags_:
+        * `earliest`: the lowest numbered block available on the client.
+        * `finalized`: the most recent crypto-economically secure block; cannot be re-orged outside of manual intervention driven by community coordination.
+        * `safe`: the most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions.
+        * `latest`: the most recent block in the canonical chain observed by the client; this block can be re-orged out of the canonical chain even under healthy/normal conditions.
+        * `pending`: a sample next block built by the client on top of the `latest` and containing the set of transactions usually taken from local mempool. In other words, it is the block that has not been mined yet.
+    2. `<string>` (quantity): the transaction index position.
+
+### Returns
+<br/>
+
+  * `blockHash` (string; data, 32 bytes): a hash of the block containing the transaction; null when it's pending.
+  * `blockNumber` (string; quantity): a number of the block containing the transaction; null when it's pending.
+  * `from` (string; data, 20 bytes): an address of the sender.
+  * `gas` (string; quantity): the gas provided by the sender.
+  * `gasPrice` (string; quantity): the gas price provided by the sender in wei.
+  * `hash` (string; data, 32 bytes): the hash of the transaction.
+  * `input` (string; data): the data send along with the transaction.
+  * `nonce` (string; quantity): the number of transactions made by the sender prior to this one.
+  * `to` (string: data, 20 bytes): an address of the receiver: null when it's a contract creation transaction.
+  * `transactionIndex` (string; quantity): the transaction index position in the block; null when it's pending.
+  * `value` (string; quantity): the value transferred in wei.
+  * `v` (string; quantity): ECDSA recovery ID.
+  * `r` (string; quantity): ECDSA signature r.
+  * `s` (string; quantity): ECDSA signature s.
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet \
+-H 'Content-Type: application/json' \
+-d '{
+      "jsonrpc": "2.0",
+      "method": "eth_getTransactionByBlockNumberAndIndex",
+      "params": ["latest", "0x1"],
+      "id": 1
+    }'
+```
+
+### Response example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "blockHash": "0x0c891cace708b8e91fa9d1396b4b4134d395b208b90fc1b3f35c0c1bb40f485d",
+        "blockNumber": "0xa2b2b",
+        "from": "0x45406041debc7813f034cdbf081ff33e1f666900",
+        "gas": "0x18af6",
+        "gasPrice": "0x1ff4c9bda",
+        "hash": "0xe6b0030513815872a1486cedc2f7dfc6a27a263244f3c16b4cf099f92e80f21f",
+        "input": "0xa9059cbb00000000000000000000000045406041debc7813f034cdbf081ff33e1f6669000000000000000000000000000000000000000000000000000000000000000000",
+        "nonce": "0x4",
+        "to": "0x0b8d50601a934ab26e7b8865e40d87cb3d49f9ad",
+        "transactionIndex": "0x1",
+        "value": "0x0",
+        "type": "0x0",
+        "chainId": "0x93e",
+        "v": "0x518e4",
+        "r": "0x16fd9a5b68973e5f7fc6187d877c9316557c05c6e4a4dc58e544e38ada270082",
+        "s": "0x631201afd8d37c44983630750917d7ae0d8fc7510cb0a7561573892c07f71fa4"
+    }
+}
+```
+
+---
+
+## `eth_getTransactionReceipt`
+
+> Returns the receipt of a transaction by transaction hash.
+
+The receipt is not available for pending transactions.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required):
+
+    1. `<string>` (data, 32 bytes): a hash of the transaction.
+
+### Returns
+<br/>
+
+  * `object`: a transaction receipt object, or null when no receipt was found:
+
+      * `transactionHash` (string; data, 32 bytes): a hash of the transaction.
+      * `transactionIndex` (string; quantity): the transactions index position in the block.
+      * `blockHash` (string; data, 32 bytes): a hash of the block containing the transaction.
+      * `blockNumber` (string; quantity): a number of the block containing the transaction.
+      * `from` (string; data, 20 bytes): an address of the sender.
+      * `to` (string; data, 20 bytes): an address of the receiver; null when it's a contract creation transaction.
+      * `cumulativeGasUsed` (string; quantity): the total amount of gas used when this transaction was executed in the block.
+      * `effectiveGasPrice` (string; quantity): the sum of the base fee and tip paid per unit of gas.
+      * `gasUsed` (string; quantity): the amount of gas used by this specific transaction alone.
+      * `contractAddress` (string; data, 20 bytes): the contract address created, if the transaction was a contract creation, otherwise null.
+      * `logs` (array): an array of log objects, which this transaction generated.
+      * `logsBloom` (string; data, 256 bytes): a bloom filter for light clients to quickly retrieve related logs.
+      * `type` (string; data): the transaction type, `0x00` for legacy transactions, `0x01` for access list types, `0x02` for dynamic fees. It also returns either of the following:
+
+          * `root` (string; data, 32 bytes): a post-transaction stateroot (pre Byzantium).
+          * `status` (string; quantity): either 1 (success) or 0 (failure).
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet \
+-H 'Content-Type: application/json' \
+-d '{
+      "jsonrpc": "2.0",
+      "method": "eth_getTransactionReceipt",
+      "params": ["0xf67b4d2caab1c16b6f292f7b220c09df038b7f38edcbe9e0915159817845ff9a"],
+      "id": 1
+    }'
+```
+
+### Response example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "blockHash": "0x256ac8ce2844b87c69895aba06138ffaa6759433306a7d86e6385b5b42b1f371",
+        "blockNumber": "0xa2aca",
+        "contractAddress": null,
+        "cumulativeGasUsed": "0x1dd14b",
+        "effectiveGasPrice": "0x59682f01",
+        "from": "0xf1a66ee4db3bfec6a4233bd10e587dacdae985a6",
+        "gasUsed": "0x5208",
+        "logs": [],
+        "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "status": "0x1",
+        "to": "0x904d60501d8b8e904673b3e0bcc7e6ae6e57a195",
+        "transactionHash": "0xf67b4d2caab1c16b6f292f7b220c09df038b7f38edcbe9e0915159817845ff9a",
+        "transactionIndex": "0x2c",
+        "type": "0x2"
+    }
+}
+```
+
+---
+
+## `eth_getUncleByBlockHashAndIndex`
+
+> Returns information about an uncle of a block by hash and uncle index position.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required):
+
+    1. `<string>` (data, 32 bytes): the hash of a block.
+    2. `<string>` (quantity): the uncle's index position.
+
+### Returns
+<br/>
+
+  * `<object>`: a block object, or null when no block was found:
+      * `number` (string; quantity): the block number; null when it's a pending block.
+      * `hash` (string; data, 32 bytes): the hash of the block; null when it's a pending block.
+      * `parentHash` (string; data, 32 bytes): the hash of the parent block.
+      * `nonce` (string; data, 8 bytes): the hash of the generated proof-of-work; null when it's a pending block.
+      * `sha3Uncles` (string; data, 32 bytes): SHA3 of the uncles data in the block.
+      * `logsBloom` (string; data, 256 bytes): the bloom filter for the logs of the block. null when its pending block.
+      * `transactionsRoot` (string; data, 32 bytes): the root of the transaction trie of the block.
+      * `stateRoot` (string; data, 32 bytes): the root of the final state trie of the block.
+      * `receiptsRoot` (string; data, 32 bytes): the root of the receipts trie of the block.
+      * `miner` (string; data, 20 bytes): the address of the beneficiary to whom the mining rewards were given.
+      * `difficulty` (string; quantity): the difficulty for this block.
+      * `totalDifficulty` (string; quantity): the total difficulty of the chain until this block.
+      * `extraData` (string; data): the **extra data** field of this block.
+      * `size` (string; quantity): the size of this block in bytes.
+      * `gasLimit` (string; quantity): the maximum gas allowed in this block.
+      * `gasUsed` (string; quantity): the total used gas by all transactions in this block.
+      * `timestamp` (string; quantity): the unix timestamp for when the block was collated.
+      * `transactions` (array of strings): an array of transaction objects, or 32 bytes transaction hashes depending on the last given parameter.
+      * `uncles` (array of strings): an array of uncle hashes.
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet \
+-H 'Content-Type: application/json' \
+-d '{
+      "jsonrpc": "2.0",
+      "method": "eth_getUncleByBlockHashAndIndex",
+      "params": ["0xc5a82afa5fda0fad21f573220ae47384da3aa122735b75e92cdd1fda6210400e", "0x1"],
+      "id": 1
+    }'
+```
+
+### Response example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": null
+}
+```
+
+---
+
+## `eth_getUncleByBlockNumberAndIndex`
+
+> Returns information about an uncle of a block by number and uncle index position.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required):
+
+    1. `<string>` (quantity|tag): either the hex value of a _block number_ or one of the following _block tags_:
+        * `earliest`: the lowest numbered block available on the client.
+        * `finalized`: the most recent crypto-economically secure block; cannot be re-orged outside of manual intervention driven by community coordination.
+        * `safe`: the most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions.
+        * `latest`: the most recent block in the canonical chain observed by the client; this block can be re-orged out of the canonical chain even under healthy/normal conditions.
+        * `pending`: a sample next block built by the client on top of the `latest` and containing the set of transactions usually taken from local mempool. In other words, it is the block that has not been mined yet.
+    2. `<string>` (quantity): the uncle's index position.
+
+### Returns
+<br/>
+
+  * `<object>`: a block object, or null when no block was found:
+      * `number` (string; quantity): the block number; null when it's a pending block.
+      * `hash` (string; data, 32 bytes): the hash of the block; null when it's a pending block.
+      * `parentHash` (string; data, 32 bytes): the hash of the parent block.
+      * `nonce` (string; data, 8 bytes): the hash of the generated proof-of-work; null when it's a pending block.
+      * `sha3Uncles` (string; data, 32 bytes): SHA3 of the uncles data in the block.
+      * `logsBloom` (string; data, 256 bytes): the bloom filter for the logs of the block. null when its pending block.
+      * `transactionsRoot` (string; data, 32 bytes): the root of the transaction trie of the block.
+      * `stateRoot` (string; data, 32 bytes): the root of the final state trie of the block.
+      * `receiptsRoot` (string; data, 32 bytes): the root of the receipts trie of the block.
+      * `miner` (string; data, 20 bytes): the address of the beneficiary to whom the mining rewards were given.
+      * `difficulty` (string; quantity): the difficulty for this block.
+      * `totalDifficulty` (string; quantity): the total difficulty of the chain until this block.
+      * `extraData` (string; data): the **extra data** field of this block.
+      * `size` (string; quantity): the size of this block in bytes.
+      * `gasLimit` (string; quantity): the maximum gas allowed in this block.
+      * `gasUsed` (string; quantity): the total used gas by all transactions in this block.
+      * `timestamp` (string; quantity): the unix timestamp for when the block was collated.
+      * `transactions` (array of strings): an array of transaction objects, or 32 bytes transaction hashes depending on the last given parameter.
+      * `uncles` (array of strings): an array of uncle hashes.
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet \
+-H 'Content-Type: application/json' \
+-d '{
+      "jsonrpc": "2.0",
+      "method": "eth_getUncleByBlockNumberAndIndex",
+      "params": ["latest", "0x2"],
+      "id": 1
+    }'
+```
+
+### Response example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": null
+}
+```
+
+---
+
+## `eth_getLogs`
+
+> Returns an array of all logs matching a given filter object.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required):
+
+      1. `object`: the filter options:
+
+         * `fromBlock` (string; quantity|tag; optional; default: "latest"): either the _block number_ or one of the following _block tags_:
+
+             * `latest`: for the last mined block.
+             * `earliest`: for the lowest numbered block available on the client.
+             * `pending`: for not yet mined transactions.
+
+         * `toBlock` (string; quantity|tag; optional; default: "latest"): either the _block number_ or one of the following _block tags_:
+
+             * `latest`: for the last mined block.
+             * `earliest`: for the lowest numbered block available on the client.
+             * `pending`: for not yet mined transactions.
+
+         * `address` (array of strings; data, 20 bytes; optional): a contract address or a list of addresses from which logs should originate.
+         * `topics` (array of strings; data; optional): an array of 32 bytes data topics. Topics are order-dependent. Each topic can also be an array of data with "or" options.
+         * `blockhash` (string; data, 32 bytes; optional; **future**): with the addition of EIP-234, `blockHash` will be a new filter option which restricts the logs returned to the single block with the 32-byte hash blockHash. Using blockHash is equivalent to `fromBlock = toBlock = the block` number with hash blockHash. If `blockHash` is present in the filter criteria, then neither `fromBlock` nor `toBlock` are allowed.
+
+### Returns
+<br/>
+
+  * `removed` (string; tag): `true` when the log was removed, due to a chain reorganization; `false` if it's a valid log.
+  * `logIndex` (string; quantity): the log index position in the block; null when it's a pending log.
+  * `transactionIndex` (string; quantity): the transactions index position log was created from; null when it's a pending log.
+  * `transactionHash` (string; data, 32 bytes): a hash of the transactions this log was created from; null when it's a pending log.
+  * `blockHash` (string; data, 32 bytes): a hash of the block containing the log; null when it's pending; null when it's a pending log.
+  * `blockNumber` (string; quantity): the number of the block containing the log; null when it's pending; null when it's a pending log.
+  * `address` (string; data, 20 bytes): an address from which this log originated.
+  * `data` (string; data): contains one or more 32 bytes non-indexed arguments of the log.
+  * `topics` (array of strings; data): an array of 0 to 4 32 bytes data of indexed log arguments. (In solidity: The first topic is the hash of the signature of the event (e.g. Deposit(address,bytes32,uint256)), except you declared the event with the anonymous specifier.)
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet \
+-H 'Content-Type: application/json' \
+-d '{
+      "jsonrpc": "2.0",
+      "method": "eth_getLogs",
+      "params": [{"address": "0x5aB420bd468BcdCa2660469cfd2AA684B6f9a0dc"}],
+      "id": 1
+    }'
+```
+
+### Response example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": [
+        {
+            "address": "0x5ab420bd468bcdca2660469cfd2aa684b6f9a0dc",
+            "topics": [
+                "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+                "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "0x0000000000000000000000007adb404e4963de23dd303114f0fa56f788bf3324",
+                "0x0000000000000000000000000000000000000000000000000000000000071b6b"
+            ],
+            "data": "0x",
+            "blockNumber": "0xa2b6a",
+            "transactionHash": "0x0f6141789a947465b4633a5eb7f91aded855086bec1944330abf1cb113b1a336",
+            "transactionIndex": "0x1",
+            "blockHash": "0x97861f11315028ce6a2e26767507ee4168ee69ac0599f48baaf8993b4c348665",
+            "logIndex": "0x2",
+            "removed": false
+        }
+    ]
+}
+```
+
+---
+
+## `debug_traceBlockByHash`
+
+> Traces the execution of all transactions within a block specified by hash.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required):
+
+    * `<blockHash>` (string; required): the hash of the block you want to trace.
+    * `tracer` (string; optional): the tracer to use for the operation. Tracers can customize the output, for example, by including only certain types of operations. Common tracers are the following:
+      * `callTracer`: generates a detailed trace of all calls, including internal contract calls. `callTracer` has the following parameters:
+        * `onlyTopCall` (boolean): if `true`, only the top-level call is traced.
+        * `tracerConfig` (object): additional options to customize the output, such as including or excluding specific call types.
+      * `prestateTracer`: traces the state of accounts before the execution of transactions.
+      * `noopTracer`: a no-operation tracer that returns minimal information.
+      * `fourByteTracer`: identifies the function signature of calls by analyzing the first four bytes of the calldata.
+      * `memoryTracer`: traces memory changes during the execution of transactions. `memoryTracer` has the following parameters:
+        * `disableMemory` (boolean): if true, memory output is omitted.
+      * `opTracer`: traces all the EVM opcodes executed during a transaction. `opTracer` has the following parameters:
+        * `includeMemory` (boolean): if true, includes memory output.
+        * `includeStack` (boolean): if true, includes stack output.
+        * `includeStorage` (boolean): if true, includes storage output.
+      * `gasTracer`: traces the gas usage of the transaction and breaks it down by operation.
+    * `timeout` (optional, string): sets a timeout for the tracing operation, expressed in milliseconds (e.g., "5s" for 5 seconds). If the operation exceeds this time, it will be terminated.
+    * `tracingOptions` (optional, object): an object to specify additional options for the trace, such as:
+      * `disableMemory` (boolean): if true, memory output is omitted.
+      * `disableStack` (boolean): if true, stack output is omitted.
+      * `disableStorage` (boolean): if true, storage output is omitted.
+
+You can create custom tracers by combining existing tracer parameters or defining new ones. The flexibility of tracers allows you to tailor the debugging output to your specific needs, focusing on different aspects of transaction execution.
+
+If you're working on specific use cases, it may be helpful to look into the Kite AI blockchain documentation to get detailed information on additional or custom tracers that may be supported.
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet/{your_token} \
+-H 'Content-Type: application/json' \
+-d '{
+    "jsonrpc": "2.0",
+    "method": "debug_traceBlockByHash",
+    "params": [
+        "0x012ddfb7ed5ebb4ff6084204f0741097eb48aa26d643148b27ba9ea44077a39f",
+        {
+            "tracer": "callTracer",
+            "timeout": "5s",
+            "tracingOptions": {
+                "disableMemory": true,
+                "disableStack": true,
+                "disableStorage": false
+            }
+        }
+    ],
+    "id": 1
+}'
+```
+
+### Response example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": [
+        {
+            "txHash": "0x0136ec61b1ea8e47757f6705134a6c2fff6872849d3016883733bb1e65eecc3e",
+            "result": {
+                "from": "0x0000777735367b36bc9b61c50022d9d0700db4ec",
+                "gas": "0x3d090",
+                "gasUsed": "0x2afdc",
+                "to": "0x1670000000000000000000000000000000010001",
+                "input": "0xda69d3db9c38bff01bf28fc5a0c36a56a657e7917db61f5228f05c5d5afa4e3e65363ea1197e968a6214a1e82df44b2220c11ef080a381e33c3610193dfcc1e7a4e458a00000000000000000000000000000000000000000000000000000000001391b410000000000000000000000000000000000000000000000000000000000a19827",
+                "calls": [
+                    {
+                        "from": "0x1670000000000000000000000000000000010001",
+                        "gas": "0x35859",
+                        "gasUsed": "0x25008",
+                        "to": "0x0167000000000000000000000000000000010001",
+                        "input": "0xda69d3db9c38bff01bf28fc5a0c36a56a657e7917db61f5228f05c5d5afa4e3e65363ea1197e968a6214a1e82df44b2220c11ef080a381e33c3610193dfcc1e7a4e458a00000000000000000000000000000000000000000000000000000000001391b410000000000000000000000000000000000000000000000000000000000a19827",
+                        "calls": [
+                            {
+                                "from": "0x1670000000000000000000000000000000010001",
+                                "gas": "0x2467b",
+                                "gasUsed": "0x1dc1",
+                                "to": "0x1670000000000000000000000000000000010002",
+                                "input": "0x28f713cc0000000000000000000000000000000000000000000000000000000000028c587369676e616c5f73657276696365000000000000000000000000000000000000",
+                                "output": "0x0000000000000000000000001670000000000000000000000000000000000005",
+                                "calls": [
+                                    {
+                                        "from": "0x1670000000000000000000000000000000010002",
+                                        "gas": "0x22ab5",
+                                        "gasUsed": "0xaa2",
+                                        "to": "0x0167000000000000000000000000000000010002",
+                                        "input": "0x28f713cc0000000000000000000000000000000000000000000000000000000000028c587369676e616c5f73657276696365000000000000000000000000000000000000",
+                                        "output": "0x0000000000000000000000001670000000000000000000000000000000000005",
+                                        "value": "0x0",
+                                        "type": "DELEGATECALL"
+                                    }
+                                ],
+                                "type": "STATICCALL"
+                            }
+                        ],
+                        "value": "0x0",
+                        "type": "DELEGATECALL"
+                    }
+                ],
+                "value": "0x0",
+                "type": "CALL"
+            }
+        }
+    ]
+}
+```
+
+---
+
+## `debug_traceBlockByNumber`
+
+> Traces the execution of all transactions within a block specified by number.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required):
+
+    * `<blockNumber>` (string; hex; required): the hex number of the block you want to trace.
+    * `tracer` (string; optional): the tracer to use for the operation. Tracers can customize the output, for example, by including only certain types of operations. Common tracers are the following:
+      * `callTracer`: generates a detailed trace of all calls, including internal contract calls. `callTracer` has the following parameters:
+        * `onlyTopCall` (boolean): if `true`, only the top-level call is traced.
+        * `tracerConfig` (object): additional options to customize the output, such as including or excluding specific call types.
+      * `prestateTracer`: traces the state of accounts before the execution of transactions.
+      * `noopTracer`: a no-operation tracer that returns minimal information.
+      * `fourByteTracer`: identifies the function signature of calls by analyzing the first four bytes of the calldata.
+      * `memoryTracer`: traces memory changes during the execution of transactions. `memoryTracer` has the following parameters:
+        * `disableMemory` (boolean): if true, memory output is omitted.
+      * `opTracer`: traces all the EVM opcodes executed during a transaction. `opTracer` has the following parameters:
+        * `includeMemory` (boolean): if true, includes memory output.
+        * `includeStack` (boolean): if true, includes stack output.
+        * `includeStorage` (boolean): if true, includes storage output.
+      * `gasTracer`: traces the gas usage of the transaction and breaks it down by operation.
+    * `timeout` (optional, string): sets a timeout for the tracing operation, expressed in milliseconds (e.g., "5s" for 5 seconds). If the operation exceeds this time, it will be terminated.
+    * `tracingOptions` (optional, object): an object to specify additional options for the trace, such as:
+      * `disableMemory` (boolean): if true, memory output is omitted.
+      * `disableStack` (boolean): if true, stack output is omitted.
+      * `disableStorage` (boolean): if true, storage output is omitted.
+
+You can create custom tracers by combining existing tracer parameters or defining new ones. The flexibility of tracers allows you to tailor the debugging output to your specific needs, focusing on different aspects of transaction execution.
+
+If you're working on specific use cases, it may be helpful to look into the Kite AI blockchain documentation to get detailed information on additional or custom tracers that may be supported.
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet/{your_token} \
+-H 'Content-Type: application/json' \
+-d '{
+    "jsonrpc": "2.0",
+    "method": "debug_traceBlockByNumber",
+    "params": [
+        "0x44CD4",
+        {
+            "tracer": "callTracer",
+            "timeout": "5s",
+            "tracingOptions": {
+                "disableMemory": true,
+                "disableStack": true,
+                "disableStorage": false
+            }
+        }
+    ],
+    "id": 1
+}'
+```
+
+### Response example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": [
+        {
+            "txHash": "0x0136ec61b1ea8e47757f6705134a6c2fff6872849d3016883733bb1e65eecc3e",
+            "result": {
+                "from": "0x0000777735367b36bc9b61c50022d9d0700db4ec",
+                "gas": "0x3d090",
+                "gasUsed": "0x2afdc",
+                "to": "0x1670000000000000000000000000000000010001",
+                "input": "0xda69d3db9c38bff01bf28fc5a0c36a56a657e7917db61f5228f05c5d5afa4e3e65363ea1197e968a6214a1e82df44b2220c11ef080a381e33c3610193dfcc1e7a4e458a00000000000000000000000000000000000000000000000000000000001391b410000000000000000000000000000000000000000000000000000000000a19827",
+                "calls": [
+                    {
+                        "from": "0x1670000000000000000000000000000000010001",
+                        "gas": "0x35859",
+                        "gasUsed": "0x25008",
+                        "to": "0x0167000000000000000000000000000000010001",
+                        "input": "0xda69d3db9c38bff01bf28fc5a0c36a56a657e7917db61f5228f05c5d5afa4e3e65363ea1197e968a6214a1e82df44b2220c11ef080a381e33c3610193dfcc1e7a4e458a00000000000000000000000000000000000000000000000000000000001391b410000000000000000000000000000000000000000000000000000000000a19827",
+                        "calls": [
+                            {
+                                "from": "0x1670000000000000000000000000000000010001",
+                                "gas": "0x2467b",
+                                "gasUsed": "0x1dc1",
+                                "to": "0x1670000000000000000000000000000000010002",
+                                "input": "0x28f713cc0000000000000000000000000000000000000000000000000000000000028c587369676e616c5f73657276696365000000000000000000000000000000000000",
+                                "output": "0x0000000000000000000000001670000000000000000000000000000000000005",
+                                "calls": [
+                                    {
+                                        "from": "0x1670000000000000000000000000000000010002",
+                                        "gas": "0x22ab5",
+                                        "gasUsed": "0xaa2",
+                                        "to": "0x0167000000000000000000000000000000010002",
+                                        "input": "0x28f713cc0000000000000000000000000000000000000000000000000000000000028c587369676e616c5f73657276696365000000000000000000000000000000000000",
+                                        "output": "0x0000000000000000000000001670000000000000000000000000000000000005",
+                                        "value": "0x0",
+                                        "type": "DELEGATECALL"
+                                    }
+                                ],
+                                "type": "STATICCALL"
+                            }
+                        ],
+                        "value": "0x0",
+                        "type": "DELEGATECALL"
+                    }
+                ],
+                "value": "0x0",
+                "type": "CALL"
+            }
+        }
+    ]
+}
+```
+
+---
+
+## `debug_traceBlock`
+
+> Traces the execution of all transactions within a block.
+
+### Parameters
+<br/>
+
+  * `id` (integer; required): a request ID (example: 1).
+  * `jsonrpc` (string; required): a JSON RPC spec used (example: 2.0).
+  * `method` (string; required): a method used for the request.
+  * `params` (array; required):
+
+    * `<blockRlp>` (string; hex; required): the RLP-encoded data of the block you want to trace.
+    * `tracer` (string; optional): the tracer to use for the operation. Tracers can customize the output, for example, by including only certain types of operations. Common tracers are the following:
+      * `callTracer`: generates a detailed trace of all calls, including internal contract calls. `callTracer` has the following parameters:
+        * `onlyTopCall` (boolean): if `true`, only the top-level call is traced.
+        * `tracerConfig` (object): additional options to customize the output, such as including or excluding specific call types.
+      * `prestateTracer`: traces the state of accounts before the execution of transactions.
+      * `noopTracer`: a no-operation tracer that returns minimal information.
+      * `fourByteTracer`: identifies the function signature of calls by analyzing the first four bytes of the calldata.
+      * `memoryTracer`: traces memory changes during the execution of transactions. `memoryTracer` has the following parameters:
+        * `disableMemory` (boolean): if true, memory output is omitted.
+      * `opTracer`: traces all the EVM opcodes executed during a transaction. `opTracer` has the following parameters:
+        * `includeMemory` (boolean): if true, includes memory output.
+        * `includeStack` (boolean): if true, includes stack output.
+        * `includeStorage` (boolean): if true, includes storage output.
+      * `gasTracer`: traces the gas usage of the transaction and breaks it down by operation.
+    * `timeout` (optional, string): sets a timeout for the tracing operation, expressed in milliseconds (e.g., "5s" for 5 seconds). If the operation exceeds this time, it will be terminated.
+    * `tracingOptions` (optional, object): an object to specify additional options for the trace, such as:
+      * `disableMemory` (boolean): if true, memory output is omitted.
+      * `disableStack` (boolean): if true, stack output is omitted.
+      * `disableStorage` (boolean): if true, storage output is omitted.
+
+You can create custom tracers by combining existing tracer parameters or defining new ones. The flexibility of tracers allows you to tailor the debugging output to your specific needs, focusing on different aspects of transaction execution.
+
+If you're working on specific use cases, it may be helpful to look into the Kite AI blockchain documentation to get detailed information on additional or custom tracers that may be supported.
+
+### Request example
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet/{your_token} \
+-H 'Content-Type: application/json' \
+-d '{
+    "jsonrpc": "2.0",
+    "method": "debug_traceBlock",
+    "params": [
+        "blockRlp",
+        {
+            "tracer": "tracerType",
+            "timeout": "timeoutDuration",
+            "tracingOptions": {
+                "disableMemory": boolean,
+                "disableStack": boolean,
+                "disableStorage": boolean
+            }
+        }
+    ],
+    "id": 1
+}'
+```
+
+### Response example
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": [
+    {
+      "type": "call",
+      "from": "0x1234...abcd", // Address initiating the transaction
+      "to": "0xabcd...1234",   // Address receiving the transaction
+      "gas": "0x5208",         // Gas provided for the transaction
+      "gasUsed": "0x2100",     // Gas actually used during execution
+      "input": "0x...",        // Input data to the transaction (usually calldata)
+      "output": "0x...",       // Output data from the transaction (e.g., return data)
+      "value": "0x0",          // Value transferred in the transaction (in wei)
+      "calls": [               // Nested calls (if any)
+        {
+          "type": "call",
+          "from": "0xabcd...1234",
+          "to": "0x1234...abcd",
+          "gas": "0x5208",
+          "gasUsed": "0x2100",
+          "input": "0x...",
+          "output": "0x...",
+          "value": "0x0"
+        }
+      ]
+    }
+  ]
+}
+```

--- a/pages/rpc-service/chains/chains-list.mdx
+++ b/pages/rpc-service/chains/chains-list.mdx
@@ -32,7 +32,7 @@ Find the chain you require and go to its docs section by clicking it.
 | [Avalanche](/rpc-service/chains/chains-list/#avalanche)         | [Ethereum](/rpc-service/chains/chains-list/#ethereum)               | [Iota](/rpc-service/chains/chains-list/#iota)                   | [Movement](/rpc-service/chains/chains-list/#movement) | [Stellar](/rpc-service/chains/chains-list/#stellar)               | [Xphere](/rpc-service/chains/chains-list/#xphere)         |
 | [B2 Network](/rpc-service/chains/chains-list/#b2-network)       | [Ethereum Beacon](/rpc-service/chains/chains-list/#eth-beacon)      | [Iota EVM](/rpc-service/chains/chains-list/#iota-evm)           | [NEAR](/rpc-service/chains/chains-list/#near)         | [Story](/rpc-service/chains/chains-list/#story)                   | [XRP](/rpc-service/chains/chains-list/#xrp)               |
 | [Bahamut](/rpc-service/chains/chains-list/#bahamut)             | [Etherlink](/rpc-service/chains/chains-list/#etherlink)             | [IoTeX](/rpc-service/chains/chains-list/#iotex)                 | [Nervos](/rpc-service/chains/chains-list/#nervos)     | [Sui](/rpc-service/chains/chains-list/#sui)                       | [zkSync Era](/rpc-service/chains/chains-list/#zksync-era) |
-| [Base](/rpc-service/chains/chains-list/#base)                   | [Fantom](/rpc-service/chains/chains-list/#fantom)                   | [Kaia](/rpc-service/chains/chains-list/#kaia)                   | [Neura](/rpc-service/chains/chains-list/#neura)       | [Swell](/rpc-service/chains/chains-list/#swell)                   |                                                           |
+| [Base](/rpc-service/chains/chains-list/#base)                   | [Fantom](/rpc-service/chains/chains-list/#fantom)                   | [Kaia](/rpc-service/chains/chains-list/#kaia)                   | [Neura](/rpc-service/chains/chains-list/#neura)       | [Swell](/rpc-service/chains/chains-list/#swell)                   | [Kite AI](/rpc-service/chains/chains-list/#kite-ai)       |
 | [Bitcoin](/rpc-service/chains/chains-list/#bitcoin)             | [Filecoin](/rpc-service/chains/chains-list/#filecoin)               | [Kava](/rpc-service/chains/chains-list/#kava)                   | [Optimism](/rpc-service/chains/chains-list/#optimism) | [Syscoin](/rpc-service/chains/chains-list/#syscoin)               |                                                           |
 | [Bitlayer](/rpc-service/chains/chains-list/#bitlayer)           | [Flare](/rpc-service/chains/chains-list/#flare)                     | [Kinto](/rpc-service/chains/chains-list/#kinto)                 | [Polkadot](/rpc-service/chains/chains-list/#polkadot) | [TAC](/rpc-service/chains/chains-list/#tac)                       |                                                           |
 | [Blast](/rpc-service/chains/chains-list/#blast)                 | [Fuel](/rpc-service/chains/chains-list/#fuel)                       | [Kusama](/rpc-service/chains/chains-list/#kusama)               | [Polygon](/rpc-service/chains/chains-list/#polygon)   | [Taiko](/rpc-service/chains/chains-list/#taiko)                   |                                                           |
@@ -10876,6 +10876,146 @@ from web3 import Web3
 
 def test_block_number(self):
     url = 'https://rpc.ankr.com/taiko_hekla'  # url string
+
+    web3 = Web3(HTTPProvider(url))
+    print(web3.eth.block_number)
+```
+  </Tab>
+</Tabs>
+
+#### Response example
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": "0x28244"
+}
+```
+
+---
+
+## Kite AI
+<br/>
+
+<img src="/docs/build/chains-list/kite.png" className="responsive-pic" width="800" />
+
+> Kite AI API is available on [Web3 API platform](https://www.ankr.com/rpc/kite).
+
+Kite AI is the first AI payment blockchain, providing foundational infrastructure that empowers autonomous agents to operate and transact with identity, payment, and verification. The network enables AI agents to discover and pay for services autonomously through features like funded wallets, scoped spending sessions, and service discovery, all while maintaining user control.
+
+Official quick links: [Website](https://gokite.ai/), [Docs](https://docs.gokite.ai/)
+
+### Networks
+
+  * Mainnet (`HTTPS` and `WSS`)
+
+### API methods
+
+For Kite AI, we support blockchain interaction via all the [applicable methods](/rpc-service/chains/chains-api/kite/) except for those listed as unsupported.
+
+#### Unsupported
+
+ <Callout type="warning">
+ This section contains a list of methods we don't support for _Premium_ service plan.
+ </Callout>
+
+ <Callout type="tip">
+ If you require any of the methods from the list, contact our Sales (`sales@ankr.com`) about moving to the _Enterprise_ service plan that can provide the services tailored to your specific needs.
+ </Callout>
+
+**HTTPS**:
+
+`eth_newFilter`, `eth_getFilterChanges`, `eth_coinbase`, `eth_hashrate`, `eth_mining`, `eth_getWork`,`eth_submitWork`, `eth_submitHashrate`, `net_peerCount`, `eth_newBlockFilter`, `eth_newPendingTransactionFilter`, `eth_uninstallFilter`, `eth_getFilterLogs`,
+
+`debug_*` (exception: `debug_traceBlockByHash`, `debug_traceBlockByNumber`, `debug_traceTransaction`, `debug_traceCall`, `debug_traceBlock`),
+
+`personal_*`, `admin_*`, `clique_*`, `les_*`, `miner_*`, `engine_*`, `parity_*`
+
+**WSS**:
+
+`txpool_content`, `txpool_inspect`, `txpool_status`, `txpool_contentFrom`
+
+### API querying
+
+#### Request example
+
+<Tabs
+  items={[
+    "cURL",
+    "Golang",
+    "Web3.JS",
+    "Python",
+  ]}
+>
+  <Tab>
+
+```shell
+curl -X POST https://rpc.ankr.com/kite_mainnet \
+-H 'Content-Type: application/json' \
+-d '{
+      "jsonrpc": "2.0",
+      "method": "eth_blockNumber",
+      "params": [],
+      "id": 1
+    }'
+```
+  </Tab>
+  <Tab>
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "github.com/ethereum/go-ethereum/ethclient"
+)
+
+func main() {
+    const url = "https://rpc.ankr.com/kite_mainnet"  // url string
+
+    rpcClient,err := ethclient.Dial(url)
+
+    if err != nil {
+        panic(err)
+    }
+
+    blockNumber, err := rpcClient.BlockNumber(context.Background())
+
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Println(blockNumber)
+}
+```
+  </Tab>
+  <Tab>
+
+```js
+const Web3 = require('web3');
+
+const url = 'https://rpc.ankr.com/kite_mainnet'  // url string
+
+const web3 = new Web3(new Web3.providers.HttpProvider(url));
+
+web3.eth.getBlockNumber((error, blockNumber) => {
+    if(!error) {
+        console.log(blockNumber);
+    } else {
+        console.log(error);
+    }
+});
+```
+  </Tab>
+  <Tab>
+
+```python
+from web3 import Web3
+
+def test_block_number(self):
+    url = 'https://rpc.ankr.com/kite_mainnet'  # url string
 
     web3 = Web3(HTTPProvider(url))
     print(web3.eth.block_number)


### PR DESCRIPTION
## Summary

Add Kite AI as a new chain in the public RPC docs. Endpoint `https://rpc.ankr.com/kite_mainnet` is already live for public access; method availability follows the same rules as Taiko (full standard JSON-RPC + premium `debug_traceBlock*`).

## Files changed

- `pages/rpc-service/chains/chains-api/kite.mdx` — new per-chain reference page, modeled on `taiko.mdx`. All curl/JS/TS/Python examples use `https://rpc.ankr.com/kite_mainnet`. `net_version` and `eth_chainId` examples carry the actual Kite mainnet chain id (`2366` / `0x93e`).
- `pages/rpc-service/chains/chains-api/_meta.json` — `"kite": "Kite AI"` inserted alphabetically between `kinto` and `kusama`.
- `pages/rpc-service/chains/chains-list.mdx` — new `## Kite AI` section after `## Taiko` (image, blurb, official quick links, applicable-methods pointer, code samples for shell/JS/TS/Python). Navigation table at the top of the page also gets a `Kite AI` entry.

## Sources

- Description blurb paraphrased from [docs.gokite.ai](https://docs.gokite.ai/) overview.
- Chain id `2366` (`0x93e`), currency `KITE`, explorer `kitescan.ai` — from [docs.gokite.ai/kite-chain/1-getting-started/network-information](https://docs.gokite.ai/kite-chain/1-getting-started/network-information).
- Public chain page: https://www.ankr.com/rpc/kite/

## Notes for reviewers

- Image asset `/docs/build/chains-list/kite.png` is referenced in both files but not added in this PR — design team to drop the PNG separately.
- In the navigation table (`chains-list.mdx` ~line 38) Kite AI is placed in the previously-empty cell rather than reshuffling the column-major grid. Easy to move if a different position is preferred.
- Premium endpoint pattern uses `https://rpc.ankr.com/kite_mainnet/{your_token}` consistent with the chain slug.

## Test plan

- [ ] Preview build renders `/rpc-service/chains/chains-api/kite/` with all sections and code examples.
- [ ] Anchor `/rpc-service/chains/chains-list/#kite-ai` resolves from the navigation table.
- [ ] No broken internal links introduced.
- [ ] Image placeholder (`kite.png`) handled before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)