### PR TITLE
ci: remove stale Ankr-network/staking-frontend checkout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,28 +53,6 @@ jobs:
           yarn install
           yarn build:stage
 
-      - uses: actions/checkout@v4
-        with:
-          ref: main
-          repository: Ankr-network/staking-frontend
-          token: ${{ secrets.ACCESS_TOKEN }}
-          path: staking-frontend
-
-      - name: Install dependencies and build doc sdk
-        run: |
-          yarn --cwd staking-frontend/packages/staking-sdk
-          cd  staking-frontend/packages/staking-sdk
-          yarn docs
-
-      - name: Copy build
-        run: |
-          cd out/staking-for-developers/sdk/
-          mkdir liquid-staking
-          cd liquid-staking
-          mkdir reference
-          cd ../../../../
-          mv staking-frontend/packages/staking-sdk/docs/*  out/staking-for-developers/sdk/liquid-staking/reference
-
       - name: Set AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
## Summary
- Deploy workflow checked out `Ankr-network/staking-frontend` to generate typedoc for the liquid-staking SDK; that repo is gone, so every `Deploy` since 2026-03-25 fails (see [run 25747350409](https://github.com/Ankr-network/ankr-docs/actions/runs/25747350409)).
- Removed the three staking-frontend steps (`checkout`, `Install dependencies and build doc sdk`, `Copy build`). Other secrets/credentials untouched.
- Existing SDK reference pages on S3 (`/docs/staking-for-developers/sdk/liquid-staking/reference/*`) will be pruned by the next `aws s3 sync --delete`. If those docs need to survive, regenerate from the `@ankr.com/staking-sdk` npm package or commit as static assets in a follow-up.

## Test plan
- [ ] Re-run `Docs deploy` against `STAGE` from this branch and confirm the build completes without the staking-frontend checkout.
- [ ] After merge into `main`, run `Docs deploy → PROD` and check `www.ankr.com/docs/` loads.
- [ ] Spot-check `/docs/staking-for-developers/sdk/liquid-staking-sdk/` still renders (intro page, served from this repo).
- [ ] Confirm whether `/docs/staking-for-developers/sdk/liquid-staking/reference/*` pages are still needed; if yes, open a follow-up for regen.