### PR TITLE
docs(sui): document gRPC-Web support for Sui gRPC

### DIFF
--- a/pages/rpc-service/chains/chains-api/sui/grpc.mdx
+++ b/pages/rpc-service/chains/chains-api/sui/grpc.mdx
@@ -37,6 +37,66 @@ Sui gRPC services are deployed across multiple regions for low-latency access. R
 
 **Archive endpoint** — provides access to historical Sui data that standard full nodes may have pruned. It exposes the same `LedgerService` API, so you can use the same client code. Use it when querying older transactions, checkpoints, or objects that are no longer available on current nodes.
 
+## gRPC-Web
+
+In addition to standard (native) gRPC over HTTP/2, the Sui gRPC API is served over **gRPC-Web** across the whole fleet (mainnet, testnet, and archive). gRPC-Web runs over HTTP/1.1 and HTTP/2 and is CORS-enabled, so it can be called directly from browsers and from runtimes that don't ship a native gRPC stack — no client-side proxy (such as Envoy) is required.
+
+In particular, the official [`@mysten/sui`](https://www.npmjs.com/package/@mysten/sui) SDK works against Ankr with its **default transport**, with no workarounds.
+
+Both transports share the same hosts, proto package (`sui.rpc.v2`), methods, and `x-token` authentication — only the wire format differs:
+
+| Transport | Address form | Typical clients |
+|-----------|--------------|-----------------|
+| Native gRPC | `sui.grpc.ankr.com:443` | `grpcurl`, Go / Rust / Java gRPC stacks |
+| gRPC-Web | `https://sui.grpc.ankr.com` | `@mysten/sui` SDK, browsers, `fetch` / `curl` |
+
+A gRPC-Web call is an HTTP `POST` to `https://<host>/<package>.<Service>/<Method>` — for example `https://sui.grpc.ankr.com/sui.rpc.v2.LedgerService/GetServiceInfo`.
+
+<Callout type="info">
+gRPC-Web responses are CORS-enabled (`access-control-allow-origin: *`) and expose the `grpc-status` / `grpc-message` trailers, so browser clients can read the call status. For convenience, responses also carry plain HTTP headers such as `x-sui-chain`, `x-sui-chain-id`, and `x-sui-checkpoint-height`.
+</Callout>
+
+### Using the `@mysten/sui` SDK
+
+Install the SDK with `npm i @mysten/sui` and point its gRPC-Web transport at the Ankr endpoint:
+
+```typescript
+import { SuiGrpcClient, GrpcWebFetchTransport } from '@mysten/sui/grpc';
+
+const client = new SuiGrpcClient({
+  network: 'mainnet',
+  transport: new GrpcWebFetchTransport({
+    baseUrl: 'https://sui.grpc.ankr.com',
+    // Premium: send your token with every call
+    // meta: { 'x-token': 'your-token' },
+  }),
+});
+
+const { response } = await client.ledgerService.getServiceInfo({});
+console.log(response.chain, response.checkpointHeight, response.server);
+// mainnet  285076503  sui-node/1.72.5-...
+
+// Other services use the same client, for example:
+// await client.ledgerService.getObject({ objectId: '0x6' });
+// await client.stateService.getBalance({ owner, coinType: '0x2::sui::SUI' });
+```
+
+### Using `curl`
+
+`GetServiceInfo` takes an empty request, so the body is a single empty gRPC-Web data frame (5 bytes: `00 00 00 00 00`):
+
+```shell
+printf '\x00\x00\x00\x00\x00' | curl -s -X POST \
+  -H 'Content-Type: application/grpc-web+proto' \
+  --data-binary @- \
+  https://sui.grpc.ankr.com/sui.rpc.v2.LedgerService/GetServiceInfo \
+  -D -
+# HTTP/2 200 · content-type: application/grpc-web · trailer: grpc-status: 0
+# x-sui-chain: mainnet · x-sui-checkpoint-height: <height>
+```
+
+For Premium access, add your token with `-H 'x-token: your-token'`.
+
 ## Methods list
 
 **Ledger Service**:


### PR DESCRIPTION
## What

Documents the new fleet-wide **gRPC-Web** support for the Sui gRPC API, on the existing Sui gRPC page.

## Why

shark-proxy `v0.26.17` (SHARK-3183) enabled gRPC-Web fleet-wide so the official `@mysten/sui` SDK works against Ankr with its **default transport** — but the docs so far only covered native gRPC (`grpcurl`). This adds the missing transport docs.

## Changes

New **gRPC-Web** section in `pages/rpc-service/chains/chains-api/sui/grpc.mdx`:
- native gRPC vs gRPC-Web comparison (same hosts, proto package `sui.rpc.v2`, methods, `x-token` auth — only wire format differs)
- CORS / browser notes + convenience `x-sui-*` response headers
- `@mysten/sui` SDK example using the default `GrpcWebFetchTransport`
- raw `curl` gRPC-Web example

## Verification

All examples verified live against production on 2026-06-09:
- `@mysten/sui` SDK (default transport) → `ledgerService.getServiceInfo` OK (mainnet, `sui-node/1.72.5`)
- `curl` gRPC-Web → `HTTP/2 200`, trailer `grpc-status: 0`, CORS preflight `204`
- testnet endpoint confirmed serving gRPC-Web as well
- Premium `x-token` confirmed forwarded by the SDK via transport `meta`

Refs: SHARK-3183 · shark-proxy w3tech/shark-proxy#781 · deploy w3tech/shark-deployments#3133

🤖 Generated with [Claude Code](https://claude.com/claude-code)
