### PR TITLE
docs(sui): JSON-RPC deprecation — phased Sui timeline (Jul→mid-Oct 2026)

### DIFF
--- a/pages/rpc-service/chains/chains-api/sui/index.mdx
+++ b/pages/rpc-service/chains/chains-api/sui/index.mdx
@@ -7,7 +7,7 @@ import { Callout } from "components";
 <img src="/docs/build/chains-list/sui.png" className="responsive-pic" width="800" />
 
 <Callout type="warning">
-**JSON-RPC deprecation notice.** The Sui JSON-RPC interface is being deprecated and will be turned off at the **end of July 2026**, in line with the Sui Foundation's network-wide deprecation timeline. Please migrate existing integrations to **gRPC** (recommended for indexers and backend services) or **GraphQL** (recommended for frontends and analytics). See the [JSON-RPC page](/rpc-service/chains/chains-api/sui/json-rpc) for details.
+**JSON-RPC deprecation notice.** In line with the Sui Foundation's updated, phased deprecation plan, the Sui JSON-RPC interface is being retired network-wide during 2026. Because Ankr runs its own Sui full nodes, Ankr's JSON-RPC endpoints keep serving until JSON-RPC support is removed from the Sui node software (**targeted mid-October 2026**); historical/pruned data may become unavailable earlier (**from September 2026**). Migrate existing integrations to **gRPC** (recommended for indexers and backend services) or **GraphQL** (recommended for frontends and analytics) as soon as possible. See the [JSON-RPC page](/rpc-service/chains/chains-api/sui/json-rpc) for the full timeline.
 </Callout>
 
 <Callout type="tip">
@@ -26,8 +26,8 @@ Ankr provides multiple interfaces for interacting with Sui — JSON-RPC, gRPC, a
 
 | Interface | Network | Endpoint | Auth |
 |-----------|---------|----------|------|
-| JSON-RPC *(deprecated, sunset end of July 2026)* | Mainnet | `https://rpc.ankr.com/sui` | Token for Premium |
-| JSON-RPC *(deprecated, sunset end of July 2026)* | Testnet | `https://rpc.ankr.com/sui_testnet` | Token for Premium |
+| JSON-RPC *(deprecated, sunset mid-Oct 2026)* | Mainnet | `https://rpc.ankr.com/sui` | Token for Premium |
+| JSON-RPC *(deprecated, sunset mid-Oct 2026)* | Testnet | `https://rpc.ankr.com/sui_testnet` | Token for Premium |
 | gRPC | Mainnet | `sui.grpc.ankr.com:443` | `x-token` header for Premium |
 | gRPC | Testnet | `sui-testnet.grpc.ankr.com:443` | `x-token` header for Premium |
 | gRPC Archive | Mainnet | `archive.sui.grpc.ankr.com:443` | `x-token` header for Premium |
@@ -56,7 +56,7 @@ See the [gRPC page](/rpc-service/chains/chains-api/sui/grpc#regions) for the ful
 ### JSON-RPC *(deprecated)*
 
 <Callout type="warning">
-Sunset at **end of July 2026**. Migrate existing integrations to gRPC or GraphQL.
+Sunset on Ankr's nodes is **targeted for mid-October 2026**, when JSON-RPC is removed from Sui full-node software (Sui Foundation public-good endpoints turn off earlier, in July 2026). Migrate existing integrations to gRPC or GraphQL.
 </Callout>
 
 The standard [JSON-RPC 2.0](https://www.jsonrpc.org/specification) interface for reading blockchain data and sending transactions. Historically the most common entry point for Sui dApps; superseded by gRPC and GraphQL going forward.

--- a/pages/rpc-service/chains/chains-api/sui/json-rpc.mdx
+++ b/pages/rpc-service/chains/chains-api/sui/json-rpc.mdx
@@ -6,12 +6,21 @@ import { Callout } from "components";
 <img src="/docs/build/chains-list/sui.png" className="responsive-pic" width="800" />
 
 <Callout type="warning">
-**Deprecation notice.** The Sui JSON-RPC interface is being deprecated and will be turned off at the **end of July 2026**, in line with the Sui Foundation's network-wide deprecation timeline. Please migrate existing integrations to:
+**Deprecation notice — JSON-RPC is being retired.** Per the Sui Foundation's updated, phased deprecation plan, JSON-RPC is being removed network-wide through 2026. Migrate existing integrations to:
 
 - **[gRPC](/rpc-service/chains/chains-api/sui/grpc)** — recommended for indexers, backend services, and most dApp use cases.
 - **[GraphQL](/rpc-service/chains/chains-api/sui/graphql)** — recommended for frontends, dashboards, and analytics tools.
 
-This page is preserved for reference until the sunset date.
+**Sui Foundation timeline:**
+
+- **July 2026** — Sui Foundation public-good JSON-RPC endpoints are turned off (Testnet: week of July 6; Mainnet: week of July 20). This affects apps pointing at Sui Foundation public endpoints, including for dev/test.
+- **August 2026** — Sui Foundation stops publishing JSON-RPC snapshots; new JSON-RPC full nodes can no longer be bootstrapped from them.
+- **September 2026** — Implicit archival fallback is removed; requests for pruned historical data over JSON-RPC may fail.
+- **Mid-October 2026** — JSON-RPC support is removed from Sui full-node software. After this point JSON-RPC is no longer available from any Sui full node.
+
+**On Ankr:** Ankr operates its own Sui full nodes, so the JSON-RPC endpoints (`https://rpc.ankr.com/sui`, `https://rpc.ankr.com/sui_testnet`) are **not** affected by the July public-good shutdown and keep serving until the mid-October 2026 software removal. Historical/pruned-data queries may start failing from September 2026 — for historical data, use the [gRPC Archive endpoint](/rpc-service/chains/chains-api/sui/grpc) (`archive.sui.grpc.ankr.com:443`). We strongly recommend migrating now to avoid disruption.
+
+This page is preserved for reference until JSON-RPC is removed.
 </Callout>
 
 > Sui API is available on [Web3 API platform](https://www.ankr.com/rpc/sui).


### PR DESCRIPTION
## What

Updates the Sui **JSON-RPC deprecation notice** to match the Sui Foundation's **updated, phased** deprecation plan. Replaces the old single-date "sunset end of July 2026" wording on the Sui overview + JSON-RPC pages.

## Why the date changes

The July 2026 dates in Sui's plan apply to **Sui Foundation public-good endpoints**. Ankr operates its **own** Sui full nodes, so Ankr's JSON-RPC endpoints (`rpc.ankr.com/sui`, `/sui_testnet`) are **not** affected by the July public-good shutdown — they keep serving until JSON-RPC is removed from the Sui node software (**~mid-October 2026**). Historical/pruned-data queries may begin failing earlier (**from September 2026**), where the gRPC Archive endpoint should be used.

## Changes

- `sui/index.mdx`: deprecation callout reworded; endpoint-table annotations (`sunset end of July 2026` → `sunset mid-Oct 2026`); inline interface callout.
- `sui/json-rpc.mdx`: callout reworded + added the **full phased timeline** (Jul → Aug → Sep → mid-Oct) and an **"On Ankr"** section pointing historical reads to the gRPC Archive endpoint.

Content-only — no routing/endpoint behavior changes. Equivalent change applied to the Docusaurus **v2** docs in a companion PR.

## Request

@BigBadAlien this is the **live** docs surface — please review, and if it looks good, **merge and deploy to production** (I don't have merge/deploy perms). `main` and `stage` are identical on these two files, so please sync `stage` as usual.

Related: MRPC-7572 (Sui JSON-RPC deprecation banner in the MRPC UI).
