### PR TITLE
Fix typos in RPC documentation navigation

### DIFF
--- a/pages/rpc-service/getting-started/intro.mdx
+++ b/pages/rpc-service/getting-started/intro.mdx
@@ -6,7 +6,7 @@ Getting Started docs will help you land on your feet safely and orient yourself 
 
 Here is your map to our basics:
 
-> `Iterface schema` — `Public: basics` — `Premium: basics` — `Team accounts` — `Projects`
+> `Interface schema` — `Public: basics` — `Premium: basics` — `Team accounts` — `Projects`
 
   * [`Interface schema`](/rpc-service/getting-started/intro/#interface-schema): your way around Web3 API interface.
   * [`Public: basics`](/rpc-service/getting-started/basics-public/): your way around Public endpoints for blockchain interaction.
@@ -20,7 +20,7 @@ Here you'll find information on what you can expect from all the main panes you'
 
 Here are panes you usually work with:
 
-> [`Chains list (Endpoints)`](/rpc-service/getting-started/intro/#chains-list) — [`Andvanced API`](/rpc-service/getting-started/intro/#advanced-api) — [`Statistics`](/rpc-service/getting-started/intro/#statistics) — [`Settings`](/rpc-service/getting-started/intro/#settings) — [`Billing`](/rpc-service/getting-started/intro/#billing)
+> [`Chains list (Endpoints)`](/rpc-service/getting-started/intro/#chains-list) — [`Advanced API`](/rpc-service/getting-started/intro/#advanced-api) — [`Statistics`](/rpc-service/getting-started/intro/#statistics) — [`Settings`](/rpc-service/getting-started/intro/#settings) — [`Billing`](/rpc-service/getting-started/intro/#billing)
 
 ### Chains list
 


### PR DESCRIPTION
Corrected spelling errors in navigation links: 
- `Iterface > `Interface` and `Andvanced` > `Advanced`.